### PR TITLE
change client.yml & server.yaml registry_config.timeout config unit to time.duration

### DIFF
--- a/examples/go-client/app/config.go
+++ b/examples/go-client/app/config.go
@@ -81,6 +81,11 @@ func initClientConfig() error {
 		panic(fmt.Sprintf("yaml.Unmarshal() = error:%s", jerrors.ErrorStack(err)))
 		return nil
 	}
+	if clientConfig.Registry_Config.Timeout, err = time.ParseDuration(clientConfig.Registry_Config.TimeoutStr); err != nil {
+		panic(fmt.Sprintf("time.ParseDuration(Registry_Config.Timeout:%#v) = error:%s", clientConfig.Registry_Config.TimeoutStr, err))
+		return nil
+	}
+
 	gxlog.CInfo("config{%#v}\n", clientConfig)
 
 	// log

--- a/examples/go-client/profiles/dev/client.yml
+++ b/examples/go-client/profiles/dev/client.yml
@@ -23,7 +23,7 @@ application_config:
     owner : "ZX"
 
 registry_config:
-    timeout	: 3
+    timeout	: "3s"
     address:
         - "127.0.0.1:2181"
 

--- a/examples/go-client/profiles/release/client.yml
+++ b/examples/go-client/profiles/release/client.yml
@@ -23,7 +23,7 @@ application_config:
     owner : "ZX"
 
 registry_config:
-    timeout	: 3
+    timeout	: "3s"
     address:
         - "127.0.0.1:2181"
 

--- a/examples/go-client/profiles/test/client.yml
+++ b/examples/go-client/profiles/test/client.yml
@@ -23,7 +23,7 @@ application_config:
     owner : "ZX"
 
 registry_config:
-    timeout	: 3
+    timeout	: "3s"
     address:
         - "127.0.0.1:2181"
 

--- a/examples/go-server/app/config.go
+++ b/examples/go-server/app/config.go
@@ -86,6 +86,10 @@ func initServerConf() *ServerConfig {
 		panic(fmt.Sprintf("time.ParseDuration(NetTimeout:%#v) = error:%s", conf.NetTimeout, err))
 		return nil
 	}
+	if conf.Registry_Config.Timeout, err = time.ParseDuration(conf.Registry_Config.TimeoutStr); err != nil {
+		panic(fmt.Sprintf("time.ParseDuration(Registry_Config.Timeout:%#v) = error:%s", conf.Registry_Config.TimeoutStr, err))
+		return nil
+	}
 
 	gxlog.CInfo("config{%#v}\n", conf)
 

--- a/examples/go-server/profiles/dev/server.yml
+++ b/examples/go-server/profiles/dev/server.yml
@@ -17,7 +17,7 @@ application_config:
     owner : "ZX"
 
 registry_config:
-    timeout	: 3
+    timeout	: "3s"
     address:
         - "127.0.0.1:2181"
 

--- a/examples/go-server/profiles/release/server.yml
+++ b/examples/go-server/profiles/release/server.yml
@@ -17,7 +17,7 @@ application_config:
     owner : "ZX"
 
 registry_config:
-    timeout	: 3
+    timeout	: "3s"
     address:
         - "127.0.0.1:2181"
 

--- a/examples/go-server/profiles/test/server.yml
+++ b/examples/go-server/profiles/test/server.yml
@@ -17,7 +17,7 @@ application_config:
     owner : "ZX"
 
 registry_config:
-    timeout	: 3
+    timeout	: "3s"
     address:
         - "127.0.0.1:2181"
 

--- a/jsonrpc/http.go
+++ b/jsonrpc/http.go
@@ -107,7 +107,7 @@ func (c *HTTPClient) Call(ctx context.Context, service registry.ServiceURL, req 
 	reqTimeout := c.options.HTTPTimeout
 	if len(service.Query.Get("timeout")) != 0 {
 		if timeout, err := strconv.Atoi(service.Query.Get("timeout")); err == nil {
-			timeoutDuration := time.Duration(timeout) * time.Millisecond
+			timeoutDuration := time.Duration(timeout) * time.Second
 			if timeoutDuration < reqTimeout {
 				reqTimeout = timeoutDuration
 			}

--- a/jsonrpc/http.go
+++ b/jsonrpc/http.go
@@ -115,7 +115,7 @@ func (c *HTTPClient) Call(ctx context.Context, service registry.ServiceURL, req 
 	if reqTimeout <= 0 {
 		reqTimeout = 1e8
 	}
-	httpHeader.Set("Timeout", fmt.Sprintf("%d", reqTimeout))
+	httpHeader.Set("Timeout", reqTimeout.String())
 	if md, ok := ctx.Value(public.DUBBOGO_CTX_KEY).(map[string]string); ok {
 		for k := range md {
 			httpHeader.Set(k, md[k])

--- a/jsonrpc/http.go
+++ b/jsonrpc/http.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -106,10 +105,10 @@ func (c *HTTPClient) Call(ctx context.Context, service registry.ServiceURL, req 
 
 	reqTimeout := c.options.HTTPTimeout
 	if len(service.Query.Get("timeout")) != 0 {
-		if timeout, err := strconv.Atoi(service.Query.Get("timeout")); err == nil {
-			timeoutDuration := time.Duration(timeout) * time.Second
-			if timeoutDuration < reqTimeout {
-				reqTimeout = timeoutDuration
+
+		if timeout, err := time.ParseDuration(service.Query.Get("timeout")+"s"); err == nil {
+			if timeout < reqTimeout {
+				reqTimeout = timeout
 			}
 		}
 	}

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"runtime"
 	"runtime/debug"
-	"strconv"
 	"sync"
 	"time"
 )
@@ -204,9 +203,9 @@ func (s *Server) handlePkg(rpc *serviceMap, conn net.Conn) {
 
 		ctx := context.Background()
 		if len(reqHeader["Timeout"]) > 0 {
-			timeout, err := strconv.ParseUint(reqHeader["Timeout"], 10, 64)
+			timeout, err := time.ParseDuration(reqHeader["Timeout"])
 			if err == nil {
-				httpTimeout = time.Duration(timeout)
+				httpTimeout = timeout
 				ctx, _ = context.WithTimeout(ctx, httpTimeout)
 			}
 			delete(reqHeader, "Timeout")

--- a/registry/consumer.go
+++ b/registry/consumer.go
@@ -65,7 +65,7 @@ func (t DubboType) Role() string {
 //////////////////////////////////////////////
 
 const (
-	DEFAULT_REGISTRY_TIMEOUT = 1
+	DEFAULT_REGISTRY_TIMEOUT = 1 * time.Second
 	ConsumerRegistryZkClient = "consumer zk registry"
 )
 
@@ -239,7 +239,7 @@ func (r *ZkConsumerRegistry) validateZookeeperClient() error {
 		r.client, err = newZookeeperClient(ConsumerRegistryZkClient, r.Address, r.RegistryConfig.Timeout)
 		if err != nil {
 			log.Warn("newZookeeperClient(name{%s}, zk addresss{%v}, timeout{%d}) = error{%v}",
-				ConsumerRegistryZkClient, r.Address, r.Timeout, err)
+				ConsumerRegistryZkClient, r.Address, r.Timeout.String(), err)
 		}
 	}
 
@@ -343,7 +343,7 @@ func (r *ZkConsumerRegistry) register(conf *ServiceConfig) error {
 	params.Add("side", (DubboType(CONSUMER)).Role())
 	params.Add("pid", processID)
 	params.Add("ip", localIP)
-	params.Add("timeout", fmt.Sprintf("%v", r.Timeout))
+	params.Add("timeout", fmt.Sprintf("%v", r.Timeout.Seconds()))
 	params.Add("timestamp", fmt.Sprintf("%d", r.birth))
 	if conf.Version != "" {
 		params.Add("version", conf.Version)

--- a/registry/provider.go
+++ b/registry/provider.go
@@ -124,7 +124,7 @@ func (r *ZkProviderRegistry) validateZookeeperClient() error {
 		r.client, err = newZookeeperClient(ProviderRegistryZkClient, r.Address, r.RegistryConfig.Timeout)
 		if err != nil {
 			log.Warn("newZookeeperClient(name{%s}, zk addresss{%v}, timeout{%d}) = error{%#v}",
-				ProviderRegistryZkClient, r.Address, r.Timeout, jerrors.ErrorStack(err))
+				ProviderRegistryZkClient, r.Address, r.Timeout.String(), jerrors.ErrorStack(err))
 		}
 	}
 	r.Unlock()
@@ -241,7 +241,7 @@ func (r *ZkProviderRegistry) register(conf *ProviderServiceConfig) error {
 	params.Add("side", (DubboType(PROVIDER)).Role())
 	params.Add("pid", processID)
 	params.Add("ip", localIP)
-	params.Add("timeout", fmt.Sprintf("%v", r.Timeout))
+	params.Add("timeout", fmt.Sprintf("%v", r.Timeout.Seconds()))
 	// params.Add("timestamp", time.Now().Format("20060102150405"))
 	params.Add("timestamp", fmt.Sprintf("%d", r.birth))
 	if conf.ServiceConfig.Version != "" {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"time"
 )
 
 import (
@@ -39,7 +40,8 @@ type RegistryConfig struct {
 	Address  []string `required:"true" yaml:"address"  json:"address,omitempty"`
 	UserName string   `yaml:"user_name" json:"user_name,omitempty"`
 	Password string   `yaml:"password" json:"password,omitempty"`
-	Timeout  int      `yaml:"timeout" default:"5" json:"timeout,omitempty"` // unit: second
+	TimeoutStr  string      `yaml:"timeout" default:"5s" json:"timeout,omitempty"` // unit: second
+	Timeout  time.Duration  `yaml:"-"  json:"-"`
 }
 
 //////////////////////////////////////////////

--- a/registry/zk_client.go
+++ b/registry/zk_client.go
@@ -22,7 +22,7 @@ type zookeeperClient struct {
 	zkAddrs       []string
 	sync.Mutex    // for conn
 	conn          *zk.Conn
-	timeout       int
+	timeout       time.Duration
 	exit          chan struct{}
 	wait          sync.WaitGroup
 	eventRegistry map[string][]*chan struct{}
@@ -63,7 +63,7 @@ func timeSecondDuration(sec int) time.Duration {
 	return time.Duration(sec) * time.Second
 }
 
-func newZookeeperClient(name string, zkAddrs []string, timeout int) (*zookeeperClient, error) {
+func newZookeeperClient(name string, zkAddrs []string, timeout time.Duration) (*zookeeperClient, error) {
 	var (
 		err   error
 		event <-chan zk.Event
@@ -78,7 +78,7 @@ func newZookeeperClient(name string, zkAddrs []string, timeout int) (*zookeeperC
 		eventRegistry: make(map[string][]*chan struct{}),
 	}
 	// connect to zookeeper
-	z.conn, event, err = zk.Connect(zkAddrs, timeSecondDuration(timeout))
+	z.conn, event, err = zk.Connect(zkAddrs, timeout)
 	if err != nil {
 		return nil, jerrors.Annotatef(err, "zk.Connect(zkAddrs:%+v)", zkAddrs)
 	}


### PR DESCRIPTION
client.yml & server.yaml registry_config.timeout的配置改成golang标准的duration string配置格式了，用到的地方根据自己对时间单位的需要自行转换