### PR TITLE
upgrade registry interface definition & fix some bug

### DIFF
--- a/examples/dubbo/go-client/app/test.go
+++ b/examples/dubbo/go-client/app/test.go
@@ -57,7 +57,7 @@ func testDubborpc(clientConfig *examples.ClientConfig, userKey string) {
 
 	user = new(DubboUser)
 	defer clientInvoker.DubboClient.Close()
-	err = clientInvoker.DubboCall(1, &conf, method, []interface{}{userKey}, user, dubbo.WithCallRequestTimeout(10e9), dubbo.WithCallResponseTimeout(10e9), dubbo.WithCallSerialID(dubbo.S_Dubbo))
+	err = clientInvoker.DubboCall(1, conf, method, []interface{}{userKey}, user, dubbo.WithCallRequestTimeout(10e9), dubbo.WithCallResponseTimeout(10e9), dubbo.WithCallSerialID(dubbo.S_Dubbo))
 	// Call service
 	if err != nil {
 		log.Error("client.Call() return error:%+v", jerrors.ErrorStack(err))

--- a/examples/jsonrpc/go-client/app/client.go
+++ b/examples/jsonrpc/go-client/app/client.go
@@ -40,7 +40,7 @@ func main() {
 	initProfiling(clientConfig)
 	initClient(clientConfig)
 
-	time.Sleep(3e9)
+	time.Sleep(10e9)
 
 	gxlog.CInfo("\n\n\nstart to test jsonrpc")
 	testJsonrpc(clientConfig, "A003", "GetUser")

--- a/examples/jsonrpc/go-client/app/test.go
+++ b/examples/jsonrpc/go-client/app/test.go
@@ -59,7 +59,7 @@ func testJsonrpc(clientConfig *examples.ClientConfig, userKey string, method str
 
 	user = new(JsonRPCUser)
 
-	err = clientInvoker.HttpCall(ctx, 1, &conf, req, user)
+	err = clientInvoker.HttpCall(ctx, 1, conf, req, user)
 	if err != nil {
 		panic(err)
 	} else {

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/dubbogo/hessian2 v0.0.0-20190330063706-e01b2c027961 h1:nGlTGXqzalnFtNqDsar2k/Gle/7pILm0MeH65fJSE7Y=
-github.com/dubbogo/hessian2 v0.0.0-20190330063706-e01b2c027961/go.mod h1:v+gfInE8fm/k3Fjkb2oUCKSO9LKbWvf+PtweEI89BmI=
 github.com/dubbogo/hessian2 v0.0.0-20190331022028-ade83b794bf2 h1:5kv4/4ptZTNcG2dzfHqXPiBHZcPPR3jshgxpHvlidew=
 github.com/dubbogo/hessian2 v0.0.0-20190331022028-ade83b794bf2/go.mod h1:v+gfInE8fm/k3Fjkb2oUCKSO9LKbWvf+PtweEI89BmI=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -11,11 +11,18 @@ type Registry interface {
 	RegisterProvider(ServiceConfigIf) error
 	//used for service consumer calling , register services cared about ,for dubbo's admin monitoring
 	RegisterConsumer(ServiceConfigIf) error
-	//used for service consumer ,start listen goroutine
-	GetListenEvent() chan *ServiceEvent
+	//used for service consumer ,start subscribe service event from registry
+	Subscribe() (Listener, error)
 
 	//input the serviceConfig , registry should return serviceUrlArray with multi location(provider nodes) available
-	GetService(*ServiceConfig) ([]*ServiceURL, error)
+	GetService(ServiceConfig) ([]*ServiceURL, error)
+	//close the registry for Elegant closing
+	Close()
+	//return if the registry is closed for consumer subscribing
+	IsClosed() bool
+}
 
+type Listener interface {
+	Next() (*ServiceEvent, error)
 	Close()
 }

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -85,8 +85,7 @@ type ZkRegistry struct {
 	listener     *zkEventListener
 
 	//for provider
-	zkPath       map[string]int // key = protocol://ip:port/interface
-	outerEventCh chan *registry.ServiceEvent
+	zkPath map[string]int // key = protocol://ip:port/interface
 }
 
 func NewZkRegistry(opts ...registry.RegistryOption) (registry.Registry, error) {
@@ -96,11 +95,10 @@ func NewZkRegistry(opts ...registry.RegistryOption) (registry.Registry, error) {
 	)
 
 	r = &ZkRegistry{
-		birth:        time.Now().UnixNano(),
-		done:         make(chan struct{}),
-		services:     make(map[string]registry.ServiceConfigIf),
-		zkPath:       make(map[string]int),
-		outerEventCh: make(chan *registry.ServiceEvent),
+		birth:    time.Now().UnixNano(),
+		done:     make(chan struct{}),
+		services: make(map[string]registry.ServiceConfigIf),
+		zkPath:   make(map[string]int),
 	}
 
 	for _, opt := range opts {
@@ -134,10 +132,10 @@ func NewZkRegistry(opts ...registry.RegistryOption) (registry.Registry, error) {
 	r.wg.Add(1)
 	go r.handleZkRestart()
 
-	if r.DubboType == registry.CONSUMER {
-		r.wg.Add(1)
-		go r.listen()
-	}
+	//if r.DubboType == registry.CONSUMER {
+	//	r.wg.Add(1)
+	//	go r.listen()
+	//}
 
 	return r, nil
 }
@@ -417,11 +415,9 @@ func (r *ZkRegistry) closeRegisters() {
 	r.client.Close()
 	r.client = nil
 	r.services = nil
-	//关闭outerListenerEvent
-	close(r.outerEventCh)
 }
 
-func (r *ZkRegistry) isClosed() bool {
+func (r *ZkRegistry) IsClosed() bool {
 	select {
 	case <-r.done:
 		return true


### PR DESCRIPTION
1.上周末一些指针引用变为对象引用，对应的listener部分没有修改完整。
2.修改了listener部分的接口定义，与java的命名一致，改为了subscribe，并且接口返回listener对象。由invoker层全面接管consumer 注册中心订阅任务的启动和监听。