### PR TITLE
code refactor for abstracting service config's interface

### DIFF
--- a/client/client_transport.go
+++ b/client/client_transport.go
@@ -1,6 +1,5 @@
 package client
 
-
 import (
 	"context"
 )
@@ -10,15 +9,14 @@ import (
 )
 
 type Transport interface {
-	Call(ctx context.Context, url *registry.ServiceURL, request Request, resp interface{}) error
-	NewRequest(conf registry.DefaultServiceConfig, method string, args interface{}) Request
+	Call(ctx context.Context, url *registry.DefaultServiceURL, request Request, resp interface{}) error
+	NewRequest(conf registry.ServiceConfig, method string, args interface{}) (Request,error)
 }
 
 //////////////////////////////////////////////
 // Request
 //////////////////////////////////////////////
 
-type Request interface  {
-	ServiceConfig() registry.DefaultServiceConfig
+type Request interface {
+	ServiceConfig() registry.ServiceConfig
 }
-

--- a/client/client_transport.go
+++ b/client/client_transport.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Transport interface {
-	Call(ctx context.Context, url *registry.DefaultServiceURL, request Request, resp interface{}) error
+	Call(ctx context.Context, url registry.ServiceURL, request Request, resp interface{}) error
 	NewRequest(conf registry.ServiceConfig, method string, args interface{}) (Request,error)
 }
 

--- a/client/invoker/invoker.go
+++ b/client/invoker/invoker.go
@@ -133,7 +133,7 @@ func (ivk *Invoker) update(res *registry.ServiceEvent) {
 		if ok {
 			svcArr.add(res.Service, ivk.ServiceTTL)
 		} else {
-			ivk.cacheServiceMap[registryKey] = newServiceArray([]*registry.DefaultServiceURL{res.Service})
+			ivk.cacheServiceMap[registryKey] = newServiceArray([]registry.ServiceURL{res.Service})
 		}
 	case registry.ServiceDel:
 		if ok {
@@ -143,7 +143,7 @@ func (ivk *Invoker) update(res *registry.ServiceEvent) {
 				log.Warn("delete registry %s from registry map", registryKey)
 			}
 		}
-		log.Error("selector delete registryURL{%s}", *res.Service)
+		log.Error("selector delete registryURL{%s}", res.Service)
 	}
 }
 
@@ -211,7 +211,7 @@ func (ivk *Invoker) DubboCall(reqId int64, registryConf registry.ServiceConfig, 
 		return err
 	}
 	//TODO:这里要改一下call方法改为接收指针类型
-	if err = ivk.DubboClient.Call(url.Ip+":"+url.Port, *url, method, args, reply, opts...); err != nil {
+	if err = ivk.DubboClient.Call(url.Ip()+":"+url.Port(), url, method, args, reply, opts...); err != nil {
 		log.Error("client.Call() return error:%+v", jerrors.ErrorStack(err))
 		return err
 	}

--- a/client/invoker/invoker.go
+++ b/client/invoker/invoker.go
@@ -133,7 +133,7 @@ func (ivk *Invoker) update(res *registry.ServiceEvent) {
 		if ok {
 			svcArr.add(res.Service, ivk.ServiceTTL)
 		} else {
-			ivk.cacheServiceMap[registryKey] = newServiceArray([]*registry.ServiceURL{res.Service})
+			ivk.cacheServiceMap[registryKey] = newServiceArray([]*registry.DefaultServiceURL{res.Service})
 		}
 	case registry.ServiceDel:
 		if ok {
@@ -147,7 +147,7 @@ func (ivk *Invoker) update(res *registry.ServiceEvent) {
 	}
 }
 
-func (ivk *Invoker) getService(registryConf registry.DefaultServiceConfig) (*ServiceArray, error) {
+func (ivk *Invoker) getService(registryConf registry.ServiceConfig) (*ServiceArray, error) {
 	defer ivk.listenerLock.Unlock()
 
 	registryKey := registryConf.Key()
@@ -197,7 +197,7 @@ func (ivk *Invoker) HttpCall(ctx context.Context, reqId int64, req client.Reques
 	return nil
 }
 
-func (ivk *Invoker) DubboCall(reqId int64, registryConf registry.DefaultServiceConfig, method string, args, reply interface{}, opts ...dubbo.CallOption) error {
+func (ivk *Invoker) DubboCall(reqId int64, registryConf registry.ServiceConfig, method string, args, reply interface{}, opts ...dubbo.CallOption) error {
 
 	registryArray, err := ivk.getService(registryConf)
 	if err != nil {

--- a/client/invoker/service_array.go
+++ b/client/invoker/service_array.go
@@ -25,12 +25,12 @@ var (
 )
 
 type ServiceArray struct {
-	arr   []*registry.DefaultServiceURL
+	arr   []registry.ServiceURL
 	birth time.Time
 	idx   int64
 }
 
-func newServiceArray(arr []*registry.DefaultServiceURL) *ServiceArray {
+func newServiceArray(arr []registry.ServiceURL) *ServiceArray {
 	return &ServiceArray{
 		arr:   arr,
 		birth: time.Now(),
@@ -45,7 +45,7 @@ func (s *ServiceArray) GetSize() int64 {
 	return int64(len(s.arr))
 }
 
-func (s *ServiceArray) GetService(i int64) *registry.DefaultServiceURL {
+func (s *ServiceArray) GetService(i int64) registry.ServiceURL {
 	return s.arr[i]
 }
 
@@ -60,14 +60,14 @@ func (s *ServiceArray) String() string {
 	return builder.String()
 }
 
-func (s *ServiceArray) add(registry *registry.DefaultServiceURL, ttl time.Duration) {
+func (s *ServiceArray) add(registry registry.ServiceURL, ttl time.Duration) {
 	s.arr = append(s.arr, registry)
 	s.birth = time.Now().Add(ttl)
 }
 
-func (s *ServiceArray) del(registry *registry.DefaultServiceURL, ttl time.Duration) {
+func (s *ServiceArray) del(registry registry.ServiceURL, ttl time.Duration) {
 	for i, svc := range s.arr {
-		if svc.PrimitiveURL == registry.PrimitiveURL {
+		if svc.PrimitiveURL() == registry.PrimitiveURL() {
 			s.arr = append(s.arr[:i], s.arr[i+1:]...)
 			s.birth = time.Now().Add(ttl)
 			break

--- a/client/invoker/service_array.go
+++ b/client/invoker/service_array.go
@@ -25,12 +25,12 @@ var (
 )
 
 type ServiceArray struct {
-	arr   []*registry.ServiceURL
+	arr   []*registry.DefaultServiceURL
 	birth time.Time
 	idx   int64
 }
 
-func newServiceArray(arr []*registry.ServiceURL) *ServiceArray {
+func newServiceArray(arr []*registry.DefaultServiceURL) *ServiceArray {
 	return &ServiceArray{
 		arr:   arr,
 		birth: time.Now(),
@@ -45,7 +45,7 @@ func (s *ServiceArray) GetSize() int64 {
 	return int64(len(s.arr))
 }
 
-func (s *ServiceArray) GetService(i int64) *registry.ServiceURL {
+func (s *ServiceArray) GetService(i int64) *registry.DefaultServiceURL {
 	return s.arr[i]
 }
 
@@ -60,12 +60,12 @@ func (s *ServiceArray) String() string {
 	return builder.String()
 }
 
-func (s *ServiceArray) add(registry *registry.ServiceURL, ttl time.Duration) {
+func (s *ServiceArray) add(registry *registry.DefaultServiceURL, ttl time.Duration) {
 	s.arr = append(s.arr, registry)
 	s.birth = time.Now().Add(ttl)
 }
 
-func (s *ServiceArray) del(registry *registry.ServiceURL, ttl time.Duration) {
+func (s *ServiceArray) del(registry *registry.DefaultServiceURL, ttl time.Duration) {
 	for i, svc := range s.arr {
 		if svc.PrimitiveURL == registry.PrimitiveURL {
 			s.arr = append(s.arr[:i], s.arr[i+1:]...)

--- a/client/selector/random.go
+++ b/client/selector/random.go
@@ -16,7 +16,7 @@ func NewRandomSelector() Selector {
 	return &RandomSelector{}
 }
 
-func (s *RandomSelector) Select(ID int64, array client.ServiceArrayIf) (*registry.DefaultServiceURL, error) {
+func (s *RandomSelector) Select(ID int64, array client.ServiceArrayIf) (registry.ServiceURL, error) {
 	if array.GetSize() == 0 {
 		return nil, ServiceArrayEmpty
 	}

--- a/client/selector/random.go
+++ b/client/selector/random.go
@@ -16,7 +16,7 @@ func NewRandomSelector() Selector {
 	return &RandomSelector{}
 }
 
-func (s *RandomSelector) Select(ID int64, array client.ServiceArrayIf) (*registry.ServiceURL, error) {
+func (s *RandomSelector) Select(ID int64, array client.ServiceArrayIf) (*registry.DefaultServiceURL, error) {
 	if array.GetSize() == 0 {
 		return nil, ServiceArrayEmpty
 	}

--- a/client/selector/round_robin.go
+++ b/client/selector/round_robin.go
@@ -15,7 +15,7 @@ func NewRoundRobinSelector() Selector {
 	return &RoundRobinSelector{}
 }
 
-func (s *RoundRobinSelector) Select(ID int64, array client.ServiceArrayIf) (*registry.ServiceURL, error) {
+func (s *RoundRobinSelector) Select(ID int64, array client.ServiceArrayIf) (*registry.DefaultServiceURL, error) {
 	if array.GetSize() == 0 {
 		return nil, ServiceArrayEmpty
 	}

--- a/client/selector/round_robin.go
+++ b/client/selector/round_robin.go
@@ -15,7 +15,7 @@ func NewRoundRobinSelector() Selector {
 	return &RoundRobinSelector{}
 }
 
-func (s *RoundRobinSelector) Select(ID int64, array client.ServiceArrayIf) (*registry.DefaultServiceURL, error) {
+func (s *RoundRobinSelector) Select(ID int64, array client.ServiceArrayIf) (registry.ServiceURL, error) {
 	if array.GetSize() == 0 {
 		return nil, ServiceArrayEmpty
 	}

--- a/client/selector/selector.go
+++ b/client/selector/selector.go
@@ -14,5 +14,5 @@ var (
 )
 
 type Selector interface {
-	Select(ID int64, array client.ServiceArrayIf) (*registry.ServiceURL, error)
+	Select(ID int64, array client.ServiceArrayIf) (*registry.DefaultServiceURL, error)
 }

--- a/client/selector/selector.go
+++ b/client/selector/selector.go
@@ -14,5 +14,5 @@ var (
 )
 
 type Selector interface {
-	Select(ID int64, array client.ServiceArrayIf) (*registry.DefaultServiceURL, error)
+	Select(ID int64, array client.ServiceArrayIf) (registry.ServiceURL, error)
 }

--- a/client/service_array.go
+++ b/client/service_array.go
@@ -1,11 +1,9 @@
 package client
 
-import (
-	"github.com/dubbo/dubbo-go/registry"
-)
+import "github.com/dubbo/dubbo-go/registry"
 
 type ServiceArrayIf interface {
 	GetIdx() *int64
 	GetSize() int64
-	GetService(i int64) *registry.DefaultServiceURL
+	GetService(i int64) registry.ServiceURL
 }

--- a/client/service_array.go
+++ b/client/service_array.go
@@ -7,5 +7,5 @@ import (
 type ServiceArrayIf interface {
 	GetIdx() *int64
 	GetSize() int64
-	GetService(i int64) *registry.ServiceURL
+	GetService(i int64) *registry.DefaultServiceURL
 }

--- a/dubbo/client.go
+++ b/dubbo/client.go
@@ -104,7 +104,7 @@ func NewClient(conf *ClientConfig) (*Client, error) {
 }
 
 // call one way
-func (c *Client) CallOneway(addr string, svcUrl registry.DefaultServiceURL, method string, args interface{}, opts ...CallOption) error {
+func (c *Client) CallOneway(addr string, svcUrl registry.ServiceURL, method string, args interface{}, opts ...CallOption) error {
 	var copts CallOptions
 
 	for _, o := range opts {
@@ -115,7 +115,7 @@ func (c *Client) CallOneway(addr string, svcUrl registry.DefaultServiceURL, meth
 }
 
 // if @reply is nil, the transport layer will get the response without notify the invoker.
-func (c *Client) Call(addr string, svcUrl registry.DefaultServiceURL, method string, args, reply interface{}, opts ...CallOption) error {
+func (c *Client) Call(addr string, svcUrl registry.ServiceURL, method string, args, reply interface{}, opts ...CallOption) error {
 	var copts CallOptions
 
 	for _, o := range opts {
@@ -130,7 +130,7 @@ func (c *Client) Call(addr string, svcUrl registry.DefaultServiceURL, method str
 	return jerrors.Trace(c.call(ct, addr, svcUrl, method, args, reply, nil, copts))
 }
 
-func (c *Client) AsyncCall(addr string, svcUrl registry.DefaultServiceURL, method string, args interface{},
+func (c *Client) AsyncCall(addr string, svcUrl registry.ServiceURL, method string, args interface{},
 	callback AsyncCallback, reply interface{}, opts ...CallOption) error {
 
 	var copts CallOptions
@@ -141,7 +141,7 @@ func (c *Client) AsyncCall(addr string, svcUrl registry.DefaultServiceURL, metho
 	return jerrors.Trace(c.call(CT_TwoWay, addr, svcUrl, method, args, reply, callback, copts))
 }
 
-func (c *Client) call(ct CallType, addr string, svcUrl registry.DefaultServiceURL, method string,
+func (c *Client) call(ct CallType, addr string, svcUrl registry.ServiceURL, method string,
 	args, reply interface{}, callback AsyncCallback, opts CallOptions) error {
 
 	if opts.RequestTimeout == 0 {
@@ -152,9 +152,9 @@ func (c *Client) call(ct CallType, addr string, svcUrl registry.DefaultServiceUR
 	}
 
 	p := &DubboPackage{}
-	p.Service.Path = strings.TrimPrefix(svcUrl.Path, "/")
-	p.Service.Target = strings.TrimPrefix(svcUrl.Path, "/")
-	p.Service.Version = svcUrl.Version
+	p.Service.Path = strings.TrimPrefix(svcUrl.Path(), "/")
+	p.Service.Target = strings.TrimPrefix(svcUrl.Path(), "/")
+	p.Service.Version = svcUrl.Version()
 	p.Service.Method = method
 	p.Service.Timeout = opts.RequestTimeout
 	//if opts.SerialID == 0 || opts.SerialID == 1 || opts.SerialID == 3 || opts.SerialID == 4 || opts.SerialID == 5 || opts.SerialID == 6 ||

--- a/dubbo/client.go
+++ b/dubbo/client.go
@@ -104,7 +104,7 @@ func NewClient(conf *ClientConfig) (*Client, error) {
 }
 
 // call one way
-func (c *Client) CallOneway(addr string, svcUrl registry.ServiceURL, method string, args interface{}, opts ...CallOption) error {
+func (c *Client) CallOneway(addr string, svcUrl registry.DefaultServiceURL, method string, args interface{}, opts ...CallOption) error {
 	var copts CallOptions
 
 	for _, o := range opts {
@@ -115,7 +115,7 @@ func (c *Client) CallOneway(addr string, svcUrl registry.ServiceURL, method stri
 }
 
 // if @reply is nil, the transport layer will get the response without notify the invoker.
-func (c *Client) Call(addr string, svcUrl registry.ServiceURL, method string, args, reply interface{}, opts ...CallOption) error {
+func (c *Client) Call(addr string, svcUrl registry.DefaultServiceURL, method string, args, reply interface{}, opts ...CallOption) error {
 	var copts CallOptions
 
 	for _, o := range opts {
@@ -130,7 +130,7 @@ func (c *Client) Call(addr string, svcUrl registry.ServiceURL, method string, ar
 	return jerrors.Trace(c.call(ct, addr, svcUrl, method, args, reply, nil, copts))
 }
 
-func (c *Client) AsyncCall(addr string, svcUrl registry.ServiceURL, method string, args interface{},
+func (c *Client) AsyncCall(addr string, svcUrl registry.DefaultServiceURL, method string, args interface{},
 	callback AsyncCallback, reply interface{}, opts ...CallOption) error {
 
 	var copts CallOptions
@@ -141,7 +141,7 @@ func (c *Client) AsyncCall(addr string, svcUrl registry.ServiceURL, method strin
 	return jerrors.Trace(c.call(CT_TwoWay, addr, svcUrl, method, args, reply, callback, copts))
 }
 
-func (c *Client) call(ct CallType, addr string, svcUrl registry.ServiceURL, method string,
+func (c *Client) call(ct CallType, addr string, svcUrl registry.DefaultServiceURL, method string,
 	args, reply interface{}, callback AsyncCallback, opts CallOptions) error {
 
 	if opts.RequestTimeout == 0 {

--- a/examples/client_config.go
+++ b/examples/client_config.go
@@ -50,9 +50,9 @@ type (
 		Application_Config registry.ApplicationConfig `yaml:"application_config" json:"application_config,omitempty"`
 		ZkRegistryConfig   zookeeper.ZkRegistryConfig `yaml:"zk_registry_config" json:"zk_registry_config,omitempty"`
 		// 一个客户端只允许使用一个service的其中一个group和其中一个version
-		ServiceConfigType  string                   `default:"default" yaml:"service_config_type" json:"service_config_type,omitempty"`
-		ServiceConfig_List []registry.ServiceConfig `yaml:"-"`
-		ServiceConfigList  []map[string]string      `yaml:"service_list" json:"service_list,omitempty"`
+		ServiceConfigType    string                   `default:"default" yaml:"service_config_type" json:"service_config_type,omitempty"`
+		ServiceConfigList    []registry.ServiceConfig `yaml:"-"`
+		ServiceConfigMapList []map[string]string      `yaml:"service_list" json:"service_list,omitempty"`
 	}
 )
 
@@ -90,11 +90,11 @@ func InitClientConfig() *ClientConfig {
 	//设置默认ProviderServiceConfig类
 	plugins.SetDefaultServiceConfig(clientConfig.ServiceConfigType)
 
-	for _, service := range clientConfig.ServiceConfigList {
+	for _, service := range clientConfig.ServiceConfigMapList {
 		svc := plugins.DefaultServiceConfig()()
 		svc.SetProtocol(service["protocol"])
 		svc.SetService(service["service"])
-		clientConfig.ServiceConfig_List = append(clientConfig.ServiceConfig_List, svc)
+		clientConfig.ServiceConfigList = append(clientConfig.ServiceConfigList, svc)
 	}
 	//动态加载service config  end
 

--- a/examples/client_config.go
+++ b/examples/client_config.go
@@ -2,7 +2,6 @@ package examples
 
 import (
 	"fmt"
-	"github.com/dubbo/dubbo-go/plugins"
 	"io/ioutil"
 	"os"
 	"path"
@@ -17,6 +16,7 @@ import (
 )
 
 import (
+	"github.com/dubbo/dubbo-go/plugins"
 	"github.com/dubbo/dubbo-go/registry"
 	"github.com/dubbo/dubbo-go/registry/zookeeper"
 )
@@ -50,9 +50,9 @@ type (
 		Application_Config registry.ApplicationConfig `yaml:"application_config" json:"application_config,omitempty"`
 		ZkRegistryConfig   zookeeper.ZkRegistryConfig `yaml:"zk_registry_config" json:"zk_registry_config,omitempty"`
 		// 一个客户端只允许使用一个service的其中一个group和其中一个version
-		ServiceConfigType string                   `default:"default" yaml:"service_config_type" json:"service_config_type,omitempty"`
-		Service_List      []registry.ServiceConfig `yaml:"-"`
-		ServiceList       []map[string]string      `yaml:"service_list" json:"service_list,omitempty"`
+		ServiceConfigType  string                   `default:"default" yaml:"service_config_type" json:"service_config_type,omitempty"`
+		ServiceConfig_List []registry.ServiceConfig `yaml:"-"`
+		ServiceConfigList  []map[string]string      `yaml:"service_list" json:"service_list,omitempty"`
 	}
 )
 
@@ -90,11 +90,11 @@ func InitClientConfig() *ClientConfig {
 	//设置默认ProviderServiceConfig类
 	plugins.SetDefaultServiceConfig(clientConfig.ServiceConfigType)
 
-	for _, service := range clientConfig.ServiceList {
+	for _, service := range clientConfig.ServiceConfigList {
 		svc := plugins.DefaultServiceConfig()()
 		svc.SetProtocol(service["protocol"])
 		svc.SetService(service["service"])
-		clientConfig.Service_List = append(clientConfig.Service_List, svc)
+		clientConfig.ServiceConfig_List = append(clientConfig.ServiceConfig_List, svc)
 	}
 	//动态加载service config  end
 

--- a/examples/client_config.go
+++ b/examples/client_config.go
@@ -2,7 +2,7 @@ package examples
 
 import (
 	"fmt"
-
+	"github.com/dubbo/dubbo-go/plugins"
 	"io/ioutil"
 	"os"
 	"path"
@@ -13,7 +13,7 @@ import (
 	"github.com/AlexStocks/goext/log"
 	log "github.com/AlexStocks/log4go"
 	jerrors "github.com/juju/errors"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 import (
@@ -50,7 +50,9 @@ type (
 		Application_Config registry.ApplicationConfig `yaml:"application_config" json:"application_config,omitempty"`
 		ZkRegistryConfig   zookeeper.ZkRegistryConfig `yaml:"zk_registry_config" json:"zk_registry_config,omitempty"`
 		// 一个客户端只允许使用一个service的其中一个group和其中一个version
-		Service_List []registry.DefaultServiceConfig `yaml:"service_list" json:"service_list,omitempty"`
+		ServiceConfigType string                   `default:"default" yaml:"service_config_type" json:"service_config_type,omitempty"`
+		Service_List      []registry.ServiceConfig `yaml:"-"`
+		ServiceList       []map[string]string      `yaml:"service_list" json:"service_list,omitempty"`
 	}
 )
 
@@ -83,6 +85,19 @@ func InitClientConfig() *ClientConfig {
 		panic(fmt.Sprintf("yaml.Unmarshal() = error:%s", jerrors.ErrorStack(err)))
 		return nil
 	}
+
+	//动态加载service config
+	//设置默认ProviderServiceConfig类
+	plugins.SetDefaultServiceConfig(clientConfig.ServiceConfigType)
+
+	for _, service := range clientConfig.ServiceList {
+		svc := plugins.DefaultServiceConfig()()
+		svc.SetProtocol(service["protocol"])
+		svc.SetService(service["service"])
+		clientConfig.Service_List = append(clientConfig.Service_List, svc)
+	}
+	//动态加载service config  end
+
 	if clientConfig.ZkRegistryConfig.Timeout, err = time.ParseDuration(clientConfig.ZkRegistryConfig.TimeoutStr); err != nil {
 		panic(fmt.Sprintf("time.ParseDuration(Registry_Config.Timeout:%#v) = error:%s", clientConfig.ZkRegistryConfig.TimeoutStr, err))
 		return nil

--- a/examples/dubbo/go-client/app/client.go
+++ b/examples/dubbo/go-client/app/client.go
@@ -85,14 +85,14 @@ func initClient(clientConfig *examples.ClientConfig) {
 		return
 	}
 
-	for idx := range clientConfig.ServiceConfig_List {
-		codecType = public.GetCodecType(clientConfig.ServiceConfig_List[idx].Protocol())
+	for idx := range clientConfig.ServiceConfigList {
+		codecType = public.GetCodecType(clientConfig.ServiceConfigList[idx].Protocol())
 		if codecType == public.CODECTYPE_UNKNOWN {
-			panic(fmt.Sprintf("unknown protocol %s", clientConfig.ServiceConfig_List[idx].Protocol()))
+			panic(fmt.Sprintf("unknown protocol %s", clientConfig.ServiceConfigList[idx].Protocol()))
 		}
 	}
 
-	for _, service := range clientConfig.ServiceConfig_List {
+	for _, service := range clientConfig.ServiceConfigList {
 		err = clientRegistry.Register(service)
 		if err != nil {
 			panic(fmt.Sprintf("registry.Register(service{%#v}) = error{%v}", service, jerrors.ErrorStack(err)))

--- a/examples/dubbo/go-client/app/client.go
+++ b/examples/dubbo/go-client/app/client.go
@@ -86,9 +86,9 @@ func initClient(clientConfig *examples.ClientConfig) {
 	}
 
 	for idx := range clientConfig.Service_List {
-		codecType = public.GetCodecType(clientConfig.Service_List[idx].Protocol)
+		codecType = public.GetCodecType(clientConfig.Service_List[idx].Protocol())
 		if codecType == public.CODECTYPE_UNKNOWN {
-			panic(fmt.Sprintf("unknown protocol %s", clientConfig.Service_List[idx].Protocol))
+			panic(fmt.Sprintf("unknown protocol %s", clientConfig.Service_List[idx].Protocol()))
 		}
 	}
 

--- a/examples/dubbo/go-client/app/client.go
+++ b/examples/dubbo/go-client/app/client.go
@@ -85,14 +85,14 @@ func initClient(clientConfig *examples.ClientConfig) {
 		return
 	}
 
-	for idx := range clientConfig.Service_List {
-		codecType = public.GetCodecType(clientConfig.Service_List[idx].Protocol())
+	for idx := range clientConfig.ServiceConfig_List {
+		codecType = public.GetCodecType(clientConfig.ServiceConfig_List[idx].Protocol())
 		if codecType == public.CODECTYPE_UNKNOWN {
-			panic(fmt.Sprintf("unknown protocol %s", clientConfig.Service_List[idx].Protocol()))
+			panic(fmt.Sprintf("unknown protocol %s", clientConfig.ServiceConfig_List[idx].Protocol()))
 		}
 	}
 
-	for _, service := range clientConfig.Service_List {
+	for _, service := range clientConfig.ServiceConfig_List {
 		err = clientRegistry.Register(service)
 		if err != nil {
 			panic(fmt.Sprintf("registry.Register(service{%#v}) = error{%v}", service, jerrors.ErrorStack(err)))

--- a/examples/dubbo/go-client/app/test.go
+++ b/examples/dubbo/go-client/app/test.go
@@ -28,14 +28,14 @@ func testDubborpc(clientConfig *examples.ClientConfig, userKey string) {
 	)
 	serviceIdx = -1
 	svc = "com.ikurento.user.UserProvider"
-	for i := range clientConfig.ServiceConfig_List {
-		if clientConfig.ServiceConfig_List[i].Service() == svc && clientConfig.ServiceConfig_List[i].Protocol() == public.CODECTYPE_DUBBO.String() {
+	for i := range clientConfig.ServiceConfigList {
+		if clientConfig.ServiceConfigList[i].Service() == svc && clientConfig.ServiceConfigList[i].Protocol() == public.CODECTYPE_DUBBO.String() {
 			serviceIdx = i
 			break
 		}
 	}
 	if serviceIdx == -1 {
-		panic(fmt.Sprintf("can not find service in config service list:%#v", clientConfig.ServiceConfig_List))
+		panic(fmt.Sprintf("can not find service in config service list:%#v", clientConfig.ServiceConfigList))
 	}
 
 	// Create request
@@ -49,7 +49,7 @@ func testDubborpc(clientConfig *examples.ClientConfig, userKey string) {
 
 	user = new(DubboUser)
 	defer clientInvoker.DubboClient.Close()
-	err = clientInvoker.DubboCall(1, clientConfig.ServiceConfig_List[serviceIdx], method, []interface{}{userKey}, user, dubbo.WithCallRequestTimeout(10e9), dubbo.WithCallResponseTimeout(10e9), dubbo.WithCallSerialID(dubbo.S_Dubbo))
+	err = clientInvoker.DubboCall(1, clientConfig.ServiceConfigList[serviceIdx], method, []interface{}{userKey}, user, dubbo.WithCallRequestTimeout(10e9), dubbo.WithCallResponseTimeout(10e9), dubbo.WithCallSerialID(dubbo.S_Dubbo))
 	// Call service
 	if err != nil {
 		log.Error("client.Call() return error:%+v", jerrors.ErrorStack(err))

--- a/examples/dubbo/go-client/app/test.go
+++ b/examples/dubbo/go-client/app/test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/dubbo/dubbo-go/dubbo"
 	"github.com/dubbo/dubbo-go/examples"
 	"github.com/dubbo/dubbo-go/public"
-	"github.com/dubbo/dubbo-go/registry"
 )
 
 func testDubborpc(clientConfig *examples.ClientConfig, userKey string) {
@@ -26,12 +25,11 @@ func testDubborpc(clientConfig *examples.ClientConfig, userKey string) {
 		method     string
 		serviceIdx int
 		user       *DubboUser
-		conf       registry.DefaultServiceConfig
 	)
 	serviceIdx = -1
 	svc = "com.ikurento.user.UserProvider"
 	for i := range clientConfig.Service_List {
-		if clientConfig.Service_List[i].Service == svc && clientConfig.Service_List[i].Protocol == public.CODECTYPE_DUBBO.String() {
+		if clientConfig.Service_List[i].Service() == svc && clientConfig.Service_List[i].Protocol() == public.CODECTYPE_DUBBO.String() {
 			serviceIdx = i
 			break
 		}
@@ -42,12 +40,6 @@ func testDubborpc(clientConfig *examples.ClientConfig, userKey string) {
 
 	// Create request
 	method = string("GetUser")
-	conf = registry.DefaultServiceConfig{
-		Group:    clientConfig.Service_List[serviceIdx].Group,
-		Protocol: public.CodecType(public.CODECTYPE_DUBBO).String(),
-		Version:  clientConfig.Service_List[serviceIdx].Version,
-		Service:  clientConfig.Service_List[serviceIdx].Service,
-	}
 
 	// registry pojo
 	hessian.RegisterJavaEnum(Gender(MAN))
@@ -57,7 +49,7 @@ func testDubborpc(clientConfig *examples.ClientConfig, userKey string) {
 
 	user = new(DubboUser)
 	defer clientInvoker.DubboClient.Close()
-	err = clientInvoker.DubboCall(1, conf, method, []interface{}{userKey}, user, dubbo.WithCallRequestTimeout(10e9), dubbo.WithCallResponseTimeout(10e9), dubbo.WithCallSerialID(dubbo.S_Dubbo))
+	err = clientInvoker.DubboCall(1, clientConfig.Service_List[serviceIdx], method, []interface{}{userKey}, user, dubbo.WithCallRequestTimeout(10e9), dubbo.WithCallResponseTimeout(10e9), dubbo.WithCallSerialID(dubbo.S_Dubbo))
 	// Call service
 	if err != nil {
 		log.Error("client.Call() return error:%+v", jerrors.ErrorStack(err))

--- a/examples/dubbo/go-client/app/test.go
+++ b/examples/dubbo/go-client/app/test.go
@@ -28,14 +28,14 @@ func testDubborpc(clientConfig *examples.ClientConfig, userKey string) {
 	)
 	serviceIdx = -1
 	svc = "com.ikurento.user.UserProvider"
-	for i := range clientConfig.Service_List {
-		if clientConfig.Service_List[i].Service() == svc && clientConfig.Service_List[i].Protocol() == public.CODECTYPE_DUBBO.String() {
+	for i := range clientConfig.ServiceConfig_List {
+		if clientConfig.ServiceConfig_List[i].Service() == svc && clientConfig.ServiceConfig_List[i].Protocol() == public.CODECTYPE_DUBBO.String() {
 			serviceIdx = i
 			break
 		}
 	}
 	if serviceIdx == -1 {
-		panic(fmt.Sprintf("can not find service in config service list:%#v", clientConfig.Service_List))
+		panic(fmt.Sprintf("can not find service in config service list:%#v", clientConfig.ServiceConfig_List))
 	}
 
 	// Create request
@@ -49,7 +49,7 @@ func testDubborpc(clientConfig *examples.ClientConfig, userKey string) {
 
 	user = new(DubboUser)
 	defer clientInvoker.DubboClient.Close()
-	err = clientInvoker.DubboCall(1, clientConfig.Service_List[serviceIdx], method, []interface{}{userKey}, user, dubbo.WithCallRequestTimeout(10e9), dubbo.WithCallResponseTimeout(10e9), dubbo.WithCallSerialID(dubbo.S_Dubbo))
+	err = clientInvoker.DubboCall(1, clientConfig.ServiceConfig_List[serviceIdx], method, []interface{}{userKey}, user, dubbo.WithCallRequestTimeout(10e9), dubbo.WithCallResponseTimeout(10e9), dubbo.WithCallSerialID(dubbo.S_Dubbo))
 	// Call service
 	if err != nil {
 		log.Error("client.Call() return error:%+v", jerrors.ErrorStack(err))

--- a/examples/jsonrpc/go-client/app/client.go
+++ b/examples/jsonrpc/go-client/app/client.go
@@ -88,14 +88,14 @@ func initClient(clientConfig *examples.ClientConfig) {
 		return
 	}
 
-	for idx := range clientConfig.Service_List {
-		codecType = public.GetCodecType(clientConfig.Service_List[idx].Protocol())
+	for idx := range clientConfig.ServiceConfig_List {
+		codecType = public.GetCodecType(clientConfig.ServiceConfig_List[idx].Protocol())
 		if codecType == public.CODECTYPE_UNKNOWN {
-			panic(fmt.Sprintf("unknown protocol %s", clientConfig.Service_List[idx].Protocol()))
+			panic(fmt.Sprintf("unknown protocol %s", clientConfig.ServiceConfig_List[idx].Protocol()))
 		}
 	}
 
-	for _, service := range clientConfig.Service_List {
+	for _, service := range clientConfig.ServiceConfig_List {
 		err = clientRegistry.Register(service)
 		if err != nil {
 			panic(fmt.Sprintf("registry.Register(service{%#v}) = error{%v}", service, jerrors.ErrorStack(err)))

--- a/examples/jsonrpc/go-client/app/client.go
+++ b/examples/jsonrpc/go-client/app/client.go
@@ -88,14 +88,14 @@ func initClient(clientConfig *examples.ClientConfig) {
 		return
 	}
 
-	for idx := range clientConfig.ServiceConfig_List {
-		codecType = public.GetCodecType(clientConfig.ServiceConfig_List[idx].Protocol())
+	for idx := range clientConfig.ServiceConfigList {
+		codecType = public.GetCodecType(clientConfig.ServiceConfigList[idx].Protocol())
 		if codecType == public.CODECTYPE_UNKNOWN {
-			panic(fmt.Sprintf("unknown protocol %s", clientConfig.ServiceConfig_List[idx].Protocol()))
+			panic(fmt.Sprintf("unknown protocol %s", clientConfig.ServiceConfigList[idx].Protocol()))
 		}
 	}
 
-	for _, service := range clientConfig.ServiceConfig_List {
+	for _, service := range clientConfig.ServiceConfigList {
 		err = clientRegistry.Register(service)
 		if err != nil {
 			panic(fmt.Sprintf("registry.Register(service{%#v}) = error{%v}", service, jerrors.ErrorStack(err)))

--- a/examples/jsonrpc/go-client/app/client.go
+++ b/examples/jsonrpc/go-client/app/client.go
@@ -89,9 +89,9 @@ func initClient(clientConfig *examples.ClientConfig) {
 	}
 
 	for idx := range clientConfig.Service_List {
-		codecType = public.GetCodecType(clientConfig.Service_List[idx].Protocol)
+		codecType = public.GetCodecType(clientConfig.Service_List[idx].Protocol())
 		if codecType == public.CODECTYPE_UNKNOWN {
-			panic(fmt.Sprintf("unknown protocol %s", clientConfig.Service_List[idx].Protocol))
+			panic(fmt.Sprintf("unknown protocol %s", clientConfig.Service_List[idx].Protocol()))
 		}
 	}
 

--- a/examples/jsonrpc/go-client/app/test.go
+++ b/examples/jsonrpc/go-client/app/test.go
@@ -11,10 +11,9 @@ import (
 )
 
 import (
+	"github.com/dubbo/dubbo-go/client"
 	"github.com/dubbo/dubbo-go/examples"
 	"github.com/dubbo/dubbo-go/public"
-	"github.com/dubbo/dubbo-go/client"
-	"github.com/dubbo/dubbo-go/registry"
 )
 
 func testJsonrpc(clientConfig *examples.ClientConfig, userKey string, method string) {
@@ -24,14 +23,13 @@ func testJsonrpc(clientConfig *examples.ClientConfig, userKey string, method str
 		serviceIdx int
 		user       *JsonRPCUser
 		ctx        context.Context
-		conf       registry.DefaultServiceConfig
 		req        client.Request
 	)
 
 	serviceIdx = -1
 	svc = "com.ikurento.user.UserProvider"
 	for i := range clientConfig.Service_List {
-		if clientConfig.Service_List[i].Service == svc && clientConfig.Service_List[i].Protocol == public.CODECTYPE_JSONRPC.String() {
+		if clientConfig.Service_List[i].Service() == svc && clientConfig.Service_List[i].Protocol() == public.CODECTYPE_JSONRPC.String() {
 			serviceIdx = i
 			break
 		}
@@ -42,14 +40,13 @@ func testJsonrpc(clientConfig *examples.ClientConfig, userKey string, method str
 
 	// Create request
 	// gxlog.CInfo("jsonrpc selected service %#v", clientConfig.Service_List[serviceIdx])
-	conf = registry.DefaultServiceConfig{
-		Group:    clientConfig.Service_List[serviceIdx].Group,
-		Protocol: public.CodecType(public.CODECTYPE_JSONRPC).String(),
-		Version:  clientConfig.Service_List[serviceIdx].Version,
-		Service:  clientConfig.Service_List[serviceIdx].Service,
-	}
+
 	// Attention the last parameter : []UserKey{userKey}
-	req = clientInvoker.HttpClient.NewRequest(conf, method, []string{userKey})
+	req, err = clientInvoker.HttpClient.NewRequest(clientConfig.Service_List[serviceIdx], method, []string{userKey})
+
+	if err != nil {
+		panic(err)
+	}
 
 	ctx = context.WithValue(context.Background(), public.DUBBOGO_CTX_KEY, map[string]string{
 		"X-Proxy-Id": "dubbogo",

--- a/examples/jsonrpc/go-client/app/test.go
+++ b/examples/jsonrpc/go-client/app/test.go
@@ -28,21 +28,21 @@ func testJsonrpc(clientConfig *examples.ClientConfig, userKey string, method str
 
 	serviceIdx = -1
 	svc = "com.ikurento.user.UserProvider"
-	for i := range clientConfig.ServiceConfig_List {
-		if clientConfig.ServiceConfig_List[i].Service() == svc && clientConfig.ServiceConfig_List[i].Protocol() == public.CODECTYPE_JSONRPC.String() {
+	for i := range clientConfig.ServiceConfigList {
+		if clientConfig.ServiceConfigList[i].Service() == svc && clientConfig.ServiceConfigList[i].Protocol() == public.CODECTYPE_JSONRPC.String() {
 			serviceIdx = i
 			break
 		}
 	}
 	if serviceIdx == -1 {
-		panic(fmt.Sprintf("can not find service in config service list:%#v", clientConfig.ServiceConfig_List))
+		panic(fmt.Sprintf("can not find service in config service list:%#v", clientConfig.ServiceConfigList))
 	}
 
 	// Create request
-	// gxlog.CInfo("jsonrpc selected service %#v", clientConfig.ServiceConfig_List[serviceIdx])
+	// gxlog.CInfo("jsonrpc selected service %#v", clientConfig.ServiceConfigList[serviceIdx])
 
 	// Attention the last parameter : []UserKey{userKey}
-	req, err = clientInvoker.HttpClient.NewRequest(clientConfig.ServiceConfig_List[serviceIdx], method, []string{userKey})
+	req, err = clientInvoker.HttpClient.NewRequest(clientConfig.ServiceConfigList[serviceIdx], method, []string{userKey})
 
 	if err != nil {
 		panic(err)

--- a/examples/jsonrpc/go-client/app/test.go
+++ b/examples/jsonrpc/go-client/app/test.go
@@ -28,21 +28,21 @@ func testJsonrpc(clientConfig *examples.ClientConfig, userKey string, method str
 
 	serviceIdx = -1
 	svc = "com.ikurento.user.UserProvider"
-	for i := range clientConfig.Service_List {
-		if clientConfig.Service_List[i].Service() == svc && clientConfig.Service_List[i].Protocol() == public.CODECTYPE_JSONRPC.String() {
+	for i := range clientConfig.ServiceConfig_List {
+		if clientConfig.ServiceConfig_List[i].Service() == svc && clientConfig.ServiceConfig_List[i].Protocol() == public.CODECTYPE_JSONRPC.String() {
 			serviceIdx = i
 			break
 		}
 	}
 	if serviceIdx == -1 {
-		panic(fmt.Sprintf("can not find service in config service list:%#v", clientConfig.Service_List))
+		panic(fmt.Sprintf("can not find service in config service list:%#v", clientConfig.ServiceConfig_List))
 	}
 
 	// Create request
-	// gxlog.CInfo("jsonrpc selected service %#v", clientConfig.Service_List[serviceIdx])
+	// gxlog.CInfo("jsonrpc selected service %#v", clientConfig.ServiceConfig_List[serviceIdx])
 
 	// Attention the last parameter : []UserKey{userKey}
-	req, err = clientInvoker.HttpClient.NewRequest(clientConfig.Service_List[serviceIdx], method, []string{userKey})
+	req, err = clientInvoker.HttpClient.NewRequest(clientConfig.ServiceConfig_List[serviceIdx], method, []string{userKey})
 
 	if err != nil {
 		panic(err)

--- a/examples/jsonrpc/go-client/profiles/dev/client.yml
+++ b/examples/jsonrpc/go-client/profiles/dev/client.yml
@@ -29,6 +29,7 @@ zk_registry_config:
     address:
         - "127.0.0.1:2181"
 
+service_config_type: "default"
 service_list:
     -
         protocol : "jsonrpc"

--- a/examples/jsonrpc/go-client/profiles/release/client.yml
+++ b/examples/jsonrpc/go-client/profiles/release/client.yml
@@ -29,6 +29,7 @@ zk_registry_config:
     address:
         - "127.0.0.1:2181"
 
+service_config_type: "default"
 service_list:
     -
         protocol : "jsonrpc"

--- a/examples/jsonrpc/go-client/profiles/test/client.yml
+++ b/examples/jsonrpc/go-client/profiles/test/client.yml
@@ -29,6 +29,7 @@ zk_registry_config:
     address:
         - "127.0.0.1:2181"
 
+service_config_type: "default"
 service_list:
     -
         protocol : "jsonrpc"

--- a/examples/jsonrpc/go-server/app/config.go
+++ b/examples/jsonrpc/go-server/app/config.go
@@ -46,11 +46,13 @@ type (
 		// Registry_Address  string `default:"192.168.35.3:2181"`
 		Registry           string                           `default:"zookeeper"  yaml:"registry" json:"registry,omitempty"`
 		ZkRegistryConfig   zookeeper.ZkRegistryConfig       `yaml:"zk_registry_config" json:"zk_registry_config,omitempty"`
-		ServiceConfig_List []registry.ProviderServiceConfig `yaml:"-"`
 
-		ServiceConfigType string                `default:"default" yaml:"service_config_type" json:"service_config_type,omitempty"`
-		ServiceConfigList []map[string]string   `yaml:"service_list" json:"service_list,omitempty"`
-		Server_List       []server.ServerConfig `yaml:"server_list" json:"server_list,omitempty"`
+
+		ServiceConfigType    string                           `default:"default" yaml:"service_config_type" json:"service_config_type,omitempty"`
+		ServiceConfigList    []registry.ProviderServiceConfig `yaml:"-"`
+		ServiceConfigMapList []map[string]string              `yaml:"service_list" json:"service_list,omitempty"`
+
+		ServerConfigList []server.ServerConfig `yaml:"server_list" json:"server_list,omitempty"`
 	}
 )
 
@@ -81,12 +83,12 @@ func initServerConf() *ServerConfig {
 	//动态加载service config
 	//设置默认ProviderServiceConfig类
 	plugins.SetDefaultProviderServiceConfig(conf.ServiceConfigType)
-	for _, service := range conf.ServiceConfigList {
+	for _, service := range conf.ServiceConfigMapList {
 
 		svc := plugins.DefaultProviderServiceConfig()()
 		svc.SetProtocol(service["protocol"])
 		svc.SetService(service["service"])
-		conf.ServiceConfig_List = append(conf.ServiceConfig_List, svc)
+		conf.ServiceConfigList = append(conf.ServiceConfigList, svc)
 	}
 	//动态加载service config  end
 	if err != nil {

--- a/examples/jsonrpc/go-server/app/config.go
+++ b/examples/jsonrpc/go-server/app/config.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/dubbo/dubbo-go/plugins"
 	"io/ioutil"
 	"os"
 	"path"
@@ -13,10 +12,11 @@ import (
 	"github.com/AlexStocks/goext/log"
 	log "github.com/AlexStocks/log4go"
 	jerrors "github.com/juju/errors"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 import (
+	"github.com/dubbo/dubbo-go/plugins"
 	"github.com/dubbo/dubbo-go/registry"
 	"github.com/dubbo/dubbo-go/registry/zookeeper"
 	"github.com/dubbo/dubbo-go/server"
@@ -44,12 +44,12 @@ type (
 		// application
 		Application_Config registry.ApplicationConfig `yaml:"application_config" json:"application_config,omitempty"`
 		// Registry_Address  string `default:"192.168.35.3:2181"`
-		Registry         string                           `default:"zookeeper"  yaml:"registry" json:"registry,omitempty"`
-		ZkRegistryConfig zookeeper.ZkRegistryConfig       `yaml:"zk_registry_config" json:"zk_registry_config,omitempty"`
-		Service_List     []registry.ProviderServiceConfig `yaml:"-"`
+		Registry           string                           `default:"zookeeper"  yaml:"registry" json:"registry,omitempty"`
+		ZkRegistryConfig   zookeeper.ZkRegistryConfig       `yaml:"zk_registry_config" json:"zk_registry_config,omitempty"`
+		ServiceConfig_List []registry.ProviderServiceConfig `yaml:"-"`
 
 		ServiceConfigType string                `default:"default" yaml:"service_config_type" json:"service_config_type,omitempty"`
-		ServiceList       []map[string]string   `yaml:"service_list" json:"service_list,omitempty"`
+		ServiceConfigList []map[string]string   `yaml:"service_list" json:"service_list,omitempty"`
 		Server_List       []server.ServerConfig `yaml:"server_list" json:"server_list,omitempty"`
 	}
 )
@@ -81,16 +81,12 @@ func initServerConf() *ServerConfig {
 	//动态加载service config
 	//设置默认ProviderServiceConfig类
 	plugins.SetDefaultProviderServiceConfig(conf.ServiceConfigType)
-	fmt.Println(1111)
-	for _, service := range conf.ServiceList {
+	for _, service := range conf.ServiceConfigList {
 
 		svc := plugins.DefaultProviderServiceConfig()()
 		svc.SetProtocol(service["protocol"])
-		fmt.Println(service["protocol"])
-		fmt.Println(svc.Protocol())
 		svc.SetService(service["service"])
-		fmt.Println(svc)
-		conf.Service_List = append(conf.Service_List, svc)
+		conf.ServiceConfig_List = append(conf.ServiceConfig_List, svc)
 	}
 	//动态加载service config  end
 	if err != nil {

--- a/examples/jsonrpc/go-server/app/server.go
+++ b/examples/jsonrpc/go-server/app/server.go
@@ -78,8 +78,8 @@ func initServer() *jsonrpc.Server {
 	// provider
 	srv = jsonrpc.NewServer(
 		jsonrpc.Registry(registry),
-		jsonrpc.ConfList(conf.Server_List),
-		jsonrpc.ServiceConfList(conf.ServiceConfig_List),
+		jsonrpc.ConfList(conf.ServerConfigList),
+		jsonrpc.ServiceConfList(conf.ServiceConfigList),
 	)
 
 	return srv

--- a/examples/jsonrpc/go-server/app/server.go
+++ b/examples/jsonrpc/go-server/app/server.go
@@ -79,7 +79,7 @@ func initServer() *jsonrpc.Server {
 	srv = jsonrpc.NewServer(
 		jsonrpc.Registry(registry),
 		jsonrpc.ConfList(conf.Server_List),
-		jsonrpc.ServiceConfList(conf.Service_List),
+		jsonrpc.ServiceConfList(conf.ServiceConfig_List),
 	)
 
 	return srv

--- a/examples/jsonrpc/go-server/profiles/dev/server.yml
+++ b/examples/jsonrpc/go-server/profiles/dev/server.yml
@@ -23,7 +23,7 @@ zk_registry_config:
     timeout	: "3s"
     address:
         - "127.0.0.1:2181"
-
+service_config_type: "default"
 service_list:
     -
         protocol : "jsonrpc"

--- a/examples/jsonrpc/go-server/profiles/release/server.yml
+++ b/examples/jsonrpc/go-server/profiles/release/server.yml
@@ -23,7 +23,7 @@ zk_registry_config:
     timeout	: "3s"
     address:
         - "127.0.0.1:2181"
-
+service_config_type: "default"
 service_list:
     -
         protocol : "jsonrpc"

--- a/examples/jsonrpc/go-server/profiles/test/server.yml
+++ b/examples/jsonrpc/go-server/profiles/test/server.yml
@@ -23,7 +23,7 @@ zk_registry_config:
     timeout	: "3s"
     address:
         - "127.0.0.1:2181"
-
+service_config_type: "default"
 service_list:
     -
         protocol : "jsonrpc"

--- a/jsonrpc/http.go
+++ b/jsonrpc/http.go
@@ -97,7 +97,7 @@ func (c *HTTPClient) NewRequest(conf registry.ServiceConfig, method string, args
 	}, nil
 }
 
-func (c *HTTPClient) Call(ctx context.Context, service *registry.DefaultServiceURL, request client.Request, rsp interface{}) error {
+func (c *HTTPClient) Call(ctx context.Context, service registry.ServiceURL, request client.Request, rsp interface{}) error {
 	// header
 	req := request.(*Request)
 	httpHeader := http.Header{}
@@ -105,8 +105,8 @@ func (c *HTTPClient) Call(ctx context.Context, service *registry.DefaultServiceU
 	httpHeader.Set("Accept", "application/json")
 
 	reqTimeout := c.options.HTTPTimeout
-	if service.Timeout != 0 && service.Timeout < reqTimeout {
-		reqTimeout = time.Duration(service.Timeout)
+	if service.Timeout() != 0 && service.Timeout() < reqTimeout {
+		reqTimeout = time.Duration(service.Timeout())
 	}
 	if reqTimeout <= 0 {
 		reqTimeout = 1e8
@@ -130,7 +130,7 @@ func (c *HTTPClient) Call(ctx context.Context, service *registry.DefaultServiceU
 		return jerrors.Trace(err)
 	}
 
-	rspBody, err := c.Do(service.Location, service.Query.Get("interface"), httpHeader, reqBody)
+	rspBody, err := c.Do(service.Location(), service.Query().Get("interface"), httpHeader, reqBody)
 	if err != nil {
 		return jerrors.Trace(err)
 	}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -14,3 +14,44 @@ var PluggableLoadbalance = map[string]func() selector.Selector{
 	"round_robin": selector.NewRoundRobinSelector,
 	"random":      selector.NewRandomSelector,
 }
+
+// service configuration plugins , related to SeviceConfig for consumer paramters / ProviderSeviceConfig for provider parameters /
+
+// TODO:ServiceEven & ServiceURL subscribed by consumer from provider's listener shoud abstract to interface
+var PluggableServiceConfig = map[string]func() registry.ServiceConfig{
+	"default": registry.NewDefaultServiceConfig,
+}
+var PluggableProviderServiceConfig = map[string]func() registry.ProviderServiceConfig{
+	"default": registry.NewDefaultProviderServiceConfig,
+}
+
+//var PluggableServiceURL = map[string]func(string) (registry.ServiceURL, error){
+//	"default": registry.NewDefaultServiceURL,
+//}
+
+var defaultServiceConfig = registry.NewDefaultServiceConfig
+var defaultProviderServiceConfig = registry.NewDefaultProviderServiceConfig
+
+//var defaultServiceURL = registry.NewDefaultServiceURL
+
+func SetDefaultServiceConfig(s string) {
+	defaultServiceConfig = PluggableServiceConfig[s]
+}
+func DefaultServiceConfig() func() registry.ServiceConfig {
+	return defaultServiceConfig
+}
+
+func SetDefaultProviderServiceConfig(s string) {
+	defaultProviderServiceConfig = PluggableProviderServiceConfig[s]
+}
+func DefaultProviderServiceConfig() func() registry.ProviderServiceConfig {
+	return defaultProviderServiceConfig
+}
+
+//
+//func SetDefaultServiceURL(s string) {
+//	defaultProviderServiceConfig = PluggableProviderServiceConfig[s]
+//}
+//func DefaultServiceURL() func() registry.ProviderServiceConfig {
+//	return defaultProviderServiceConfig
+//}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -3,12 +3,9 @@ package plugins
 import (
 	"github.com/dubbo/dubbo-go/client/selector"
 	"github.com/dubbo/dubbo-go/registry"
-	"github.com/dubbo/dubbo-go/registry/zookeeper"
 )
 
-var PluggableRegistries = map[string]func(...registry.RegistryOption) (registry.Registry, error){
-	"zookeeper": zookeeper.NewZkRegistry,
-}
+var PluggableRegistries = map[string]func(...registry.RegistryOption) (registry.Registry, error){}
 
 var PluggableLoadbalance = map[string]func() selector.Selector{
 	"round_robin": selector.NewRoundRobinSelector,
@@ -25,14 +22,14 @@ var PluggableProviderServiceConfig = map[string]func() registry.ProviderServiceC
 	"default": registry.NewDefaultProviderServiceConfig,
 }
 
-//var PluggableServiceURL = map[string]func(string) (registry.ServiceURL, error){
-//	"default": registry.NewDefaultServiceURL,
-//}
+var PluggableServiceURL = map[string]func(string) (registry.ServiceURL, error){
+	"default": registry.NewDefaultServiceURL,
+}
 
 var defaultServiceConfig = registry.NewDefaultServiceConfig
 var defaultProviderServiceConfig = registry.NewDefaultProviderServiceConfig
 
-//var defaultServiceURL = registry.NewDefaultServiceURL
+var defaultServiceURL = registry.NewDefaultServiceURL
 
 func SetDefaultServiceConfig(s string) {
 	defaultServiceConfig = PluggableServiceConfig[s]
@@ -48,10 +45,9 @@ func DefaultProviderServiceConfig() func() registry.ProviderServiceConfig {
 	return defaultProviderServiceConfig
 }
 
-//
-//func SetDefaultServiceURL(s string) {
-//	defaultProviderServiceConfig = PluggableProviderServiceConfig[s]
-//}
-//func DefaultServiceURL() func() registry.ProviderServiceConfig {
-//	return defaultProviderServiceConfig
-//}
+func SetDefaultServiceURL(s string) {
+	defaultServiceURL = PluggableServiceURL[s]
+}
+func DefaultServiceURL() func(string) (registry.ServiceURL, error) {
+	return defaultServiceURL
+}

--- a/registry/event.go
+++ b/registry/event.go
@@ -36,7 +36,7 @@ func (t ServiceEventType) String() string {
 
 type ServiceEvent struct {
 	Action  ServiceEventType
-	Service *ServiceURL
+	Service *DefaultServiceURL
 }
 
 func (e ServiceEvent) String() string {

--- a/registry/event.go
+++ b/registry/event.go
@@ -36,7 +36,7 @@ func (t ServiceEventType) String() string {
 
 type ServiceEvent struct {
 	Action  ServiceEventType
-	Service *DefaultServiceURL
+	Service ServiceURL
 }
 
 func (e ServiceEvent) String() string {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -15,7 +15,7 @@ type Registry interface {
 	Subscribe() (Listener, error)
 
 	//input the serviceConfig , registry should return serviceUrlArray with multi location(provider nodes) available
-	GetService(ServiceConfig) ([]*DefaultServiceURL, error)
+	GetService(ServiceConfig) ([]ServiceURL, error)
 	//close the registry for Elegant closing
 	Close()
 	//return if the registry is closed for consumer subscribing

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -15,7 +15,7 @@ type Registry interface {
 	Subscribe() (Listener, error)
 
 	//input the serviceConfig , registry should return serviceUrlArray with multi location(provider nodes) available
-	GetService(DefaultServiceConfig) ([]*ServiceURL, error)
+	GetService(ServiceConfig) ([]*DefaultServiceURL, error)
 	//close the registry for Elegant closing
 	Close()
 	//return if the registry is closed for consumer subscribing

--- a/registry/service.go
+++ b/registry/service.go
@@ -28,25 +28,17 @@ type ServiceConfig interface {
 	Group() string
 	SetProtocol(string)
 	SetService(string)
+	SetVersion(string)
+	SetGroup(string)
 }
 
 type ProviderServiceConfig interface {
-	Key() string
-	String() string
-	ServiceEqual(url *DefaultServiceURL) bool
 	//your service config implements must contain properties below
-	Service() string
-	Protocol() string
-	Version() string
-	Group() string
+	ServiceConfig
 	Methods() string
 	Path() string
-	SetService(string)
-	SetVersion(string)
 	SetMethods(string)
 	SetPath(string)
-	SetProtocol(string)
-	SetGroup(string)
 }
 
 type DefaultServiceConfig struct {
@@ -110,6 +102,13 @@ func (c *DefaultServiceConfig) SetProtocol(s string) {
 func (c *DefaultServiceConfig) SetService(s string) {
 	c.DService = s
 }
+func (c *DefaultServiceConfig) SetVersion(s string) {
+	c.DVersion = s
+}
+
+func (c *DefaultServiceConfig) SetGroup(s string) {
+	c.DGroup = s
+}
 
 type DefaultProviderServiceConfig struct {
 	*DefaultServiceConfig
@@ -131,20 +130,12 @@ func (c *DefaultProviderServiceConfig) Path() string {
 	return c.DPath
 }
 
-func (c *DefaultProviderServiceConfig) SetVersion(s string) {
-	c.DVersion = s
-}
-
 func (c *DefaultProviderServiceConfig) SetMethods(s string) {
 	c.DMethods = s
 }
 
 func (c *DefaultProviderServiceConfig) SetPath(s string) {
 	c.DPath = s
-}
-
-func (c *DefaultProviderServiceConfig) SetGroup(s string) {
-	c.DGroup = s
 }
 
 //////////////////////////////////////////

--- a/registry/service.go
+++ b/registry/service.go
@@ -42,10 +42,10 @@ type ProviderServiceConfig interface {
 }
 
 type DefaultServiceConfig struct {
-	DProtocol string `required:"true",default:"dubbo"  yaml:"protocol"  json:"protocol,omitempty"`
-	DService  string `required:"true"  yaml:"service"  json:"service,omitempty"`
-	DGroup    string `yaml:"group" json:"group,omitempty"`
-	DVersion  string `yaml:"version" json:"version,omitempty"`
+	Protocol_ string `required:"true",default:"dubbo"  yaml:"protocol"  json:"protocol,omitempty"`
+	Service_  string `required:"true"  yaml:"service"  json:"service,omitempty"`
+	Group_    string `yaml:"group" json:"group,omitempty"`
+	Version_  string `yaml:"version" json:"version,omitempty"`
 }
 
 func NewDefaultServiceConfig() ServiceConfig {
@@ -53,27 +53,27 @@ func NewDefaultServiceConfig() ServiceConfig {
 }
 
 func (c *DefaultServiceConfig) Key() string {
-	return fmt.Sprintf("%s@%s", c.DService, c.DProtocol)
+	return fmt.Sprintf("%s@%s", c.Service_, c.Protocol_)
 }
 
 func (c *DefaultServiceConfig) String() string {
-	return fmt.Sprintf("%s@%s-%s-%s", c.DService, c.DProtocol, c.DGroup, c.DVersion)
+	return fmt.Sprintf("%s@%s-%s-%s", c.Service_, c.Protocol_, c.Group_, c.Version_)
 }
 
 func (c *DefaultServiceConfig) ServiceEqual(url ServiceURL) bool {
-	if c.DProtocol != url.Protocol() {
+	if c.Protocol_ != url.Protocol() {
 		return false
 	}
 
-	if c.DService != url.Query().Get("interface") {
+	if c.Service_ != url.Query().Get("interface") {
 		return false
 	}
 
-	if c.DGroup != url.Group() {
+	if c.Group_ != url.Group() {
 		return false
 	}
 
-	if c.DVersion != url.Version() {
+	if c.Version_ != url.Version() {
 		return false
 	}
 
@@ -81,39 +81,39 @@ func (c *DefaultServiceConfig) ServiceEqual(url ServiceURL) bool {
 }
 
 func (c *DefaultServiceConfig) Service() string {
-	return c.DService
+	return c.Service_
 }
 
 func (c *DefaultServiceConfig) Protocol() string {
-	return c.DProtocol
+	return c.Protocol_
 }
 
 func (c *DefaultServiceConfig) Version() string {
-	return c.DVersion
+	return c.Version_
 }
 
 func (c *DefaultServiceConfig) Group() string {
-	return c.DGroup
+	return c.Group_
 }
 func (c *DefaultServiceConfig) SetProtocol(s string) {
-	c.DProtocol = s
+	c.Protocol_ = s
 }
 
 func (c *DefaultServiceConfig) SetService(s string) {
-	c.DService = s
+	c.Service_ = s
 }
 func (c *DefaultServiceConfig) SetVersion(s string) {
-	c.DVersion = s
+	c.Version_ = s
 }
 
 func (c *DefaultServiceConfig) SetGroup(s string) {
-	c.DGroup = s
+	c.Group_ = s
 }
 
 type DefaultProviderServiceConfig struct {
 	*DefaultServiceConfig
-	DPath    string `yaml:"path" json:"path,omitempty"`
-	DMethods string `yaml:"methods" json:"methods,omitempty"`
+	Path_    string `yaml:"path" json:"path,omitempty"`
+	Methods_ string `yaml:"methods" json:"methods,omitempty"`
 }
 
 func NewDefaultProviderServiceConfig() ProviderServiceConfig {
@@ -123,19 +123,19 @@ func NewDefaultProviderServiceConfig() ProviderServiceConfig {
 }
 
 func (c *DefaultProviderServiceConfig) Methods() string {
-	return c.DMethods
+	return c.Methods_
 }
 
 func (c *DefaultProviderServiceConfig) Path() string {
-	return c.DPath
+	return c.Path_
 }
 
 func (c *DefaultProviderServiceConfig) SetMethods(s string) {
-	c.DMethods = s
+	c.Methods_ = s
 }
 
 func (c *DefaultProviderServiceConfig) SetPath(s string) {
-	c.DPath = s
+	c.Path_ = s
 }
 
 //////////////////////////////////////////
@@ -158,17 +158,17 @@ type ServiceURL interface {
 }
 
 type DefaultServiceURL struct {
-	DProtocol     string
-	DLocation     string // ip+port
-	DPath         string // like  /com.ikurento.dubbo.UserProvider3
-	DIp           string
-	DPort         string
-	DTimeout      time.Duration
-	DVersion      string
-	DGroup        string
-	DQuery        url.Values
-	Weight        int32
-	DPrimitiveURL string
+	Protocol_     string
+	Location_     string // ip+port
+	Path_         string // like  /com.ikurento.dubbo.UserProvider3
+	Ip_           string
+	Port_         string
+	Timeout_      time.Duration
+	Version_      string
+	Group_        string
+	Query_        url.Values
+	Weight_       int32
+	PrimitiveURL_ string
 }
 
 func NewDefaultServiceURL(urlString string) (ServiceURL, error) {
@@ -189,31 +189,31 @@ func NewDefaultServiceURL(urlString string) (ServiceURL, error) {
 		return nil, jerrors.Errorf("url.Parse(url string{%s}),  error{%v}", rawUrlString, err)
 	}
 
-	s.DQuery, err = url.ParseQuery(serviceUrl.RawQuery)
+	s.Query_, err = url.ParseQuery(serviceUrl.RawQuery)
 	if err != nil {
 		return nil, jerrors.Errorf("url.ParseQuery(raw url string{%s}),  error{%v}", serviceUrl.RawQuery, err)
 	}
 
-	s.DPrimitiveURL = urlString
-	s.DProtocol = serviceUrl.Scheme
-	s.DLocation = serviceUrl.Host
-	s.DPath = serviceUrl.Path
-	if strings.Contains(s.DLocation, ":") {
-		s.DIp, s.DPort, err = net.SplitHostPort(s.DLocation)
+	s.PrimitiveURL_ = urlString
+	s.Protocol_ = serviceUrl.Scheme
+	s.Location_ = serviceUrl.Host
+	s.Path_ = serviceUrl.Path
+	if strings.Contains(s.Location_, ":") {
+		s.Ip_, s.Port_, err = net.SplitHostPort(s.Location_)
 		if err != nil {
-			return nil, jerrors.Errorf("net.SplitHostPort(Url.Host{%s}), error{%v}", s.DLocation, err)
+			return nil, jerrors.Errorf("net.SplitHostPort(Url.Host{%s}), error{%v}", s.Location_, err)
 		}
 	}
-	s.DGroup = s.DQuery.Get("group")
-	s.DVersion = s.DQuery.Get("version")
-	timeoutStr := s.DQuery.Get("timeout")
+	s.Group_ = s.Query_.Get("group")
+	s.Version_ = s.Query_.Get("version")
+	timeoutStr := s.Query_.Get("timeout")
 	if len(timeoutStr) == 0 {
-		timeoutStr = s.DQuery.Get("default.timeout")
+		timeoutStr = s.Query_.Get("default.timeout")
 	}
 	if len(timeoutStr) != 0 {
 		timeout, err := strconv.Atoi(timeoutStr)
 		if err == nil && timeout != 0 {
-			s.DTimeout = time.Duration(timeout * 1e6) // timeout unit is millisecond
+			s.Timeout_ = time.Duration(timeout * 1e6) // timeout unit is millisecond
 		}
 	}
 
@@ -223,18 +223,18 @@ func NewDefaultServiceURL(urlString string) (ServiceURL, error) {
 func (s DefaultServiceURL) String() string {
 	return fmt.Sprintf(
 		"DefaultServiceURL{Protocol:%s, Location:%s, Path:%s, Ip:%s, Port:%s, "+
-			"Timeout:%s, Version:%s, Group:%s, Weight:%d, Query:%+v}",
-		s.DProtocol, s.DLocation, s.DPath, s.DIp, s.DPort,
-		s.DTimeout, s.DVersion, s.DGroup, s.Weight, s.DQuery)
+			"Timeout:%s, Version:%s, Group:%s, Weight_:%d, Query:%+v}",
+		s.Protocol_, s.Location_, s.Path_, s.Ip_, s.Port_,
+		s.Timeout_, s.Version_, s.Group_, s.Weight_, s.Query_)
 }
 
 func (s *DefaultServiceURL) ServiceConfig() ServiceConfig {
-	interfaceName := s.DQuery.Get("interface")
+	interfaceName := s.Query_.Get("interface")
 	return &DefaultServiceConfig{
-		DProtocol: s.DProtocol,
-		DService:  interfaceName,
-		DGroup:    s.DGroup,
-		DVersion:  s.DVersion,
+		Protocol_: s.Protocol_,
+		Service_:  interfaceName,
+		Group_:    s.Group_,
+		Version_:  s.Version_,
 	}
 }
 
@@ -243,7 +243,7 @@ func (s *DefaultServiceURL) CheckMethod(method string) bool {
 		methodArray []string
 	)
 
-	methodArray = strings.Split(s.DQuery.Get("methods"), ",")
+	methodArray = strings.Split(s.Query_.Get("methods"), ",")
 	for _, m := range methodArray {
 		if m == method {
 			return true
@@ -254,40 +254,40 @@ func (s *DefaultServiceURL) CheckMethod(method string) bool {
 }
 
 func (s *DefaultServiceURL) PrimitiveURL() string {
-	return s.DPrimitiveURL
+	return s.PrimitiveURL_
 }
 
 func (s *DefaultServiceURL) Timeout() time.Duration {
-	return s.DTimeout
+	return s.Timeout_
 }
 func (s *DefaultServiceURL) Location() string {
-	return s.DLocation
+	return s.Location_
 }
 
 func (s *DefaultServiceURL) Query() url.Values {
-	return s.DQuery
+	return s.Query_
 }
 
 func (s *DefaultServiceURL) Group() string {
-	return s.DGroup
+	return s.Group_
 }
 
 func (s *DefaultServiceURL) Protocol() string {
-	return s.DProtocol
+	return s.Protocol_
 }
 
 func (s *DefaultServiceURL) Version() string {
-	return s.DVersion
+	return s.Version_
 }
 
 func (s *DefaultServiceURL) Ip() string {
-	return s.DIp
+	return s.Ip_
 }
 
 func (s *DefaultServiceURL) Port() string {
-	return s.DPort
+	return s.Port_
 }
 
 func (s *DefaultServiceURL) Path() string {
-	return s.DPath
+	return s.Path_
 }

--- a/registry/service.go
+++ b/registry/service.go
@@ -20,55 +20,143 @@ import (
 type ServiceConfig interface {
 	Key() string
 	String() string
-	ServiceEqual(url *ServiceURL) bool
+	ServiceEqual(url *DefaultServiceURL) bool
+	//your service config implements must contain properties below
+	Service() string
+	Protocol() string
+	Version() string
+	Group() string
+	SetProtocol(string)
+	SetService(string)
+}
+
+type ProviderServiceConfig interface {
+	Key() string
+	String() string
+	ServiceEqual(url *DefaultServiceURL) bool
+	//your service config implements must contain properties below
+	Service() string
+	Protocol() string
+	Version() string
+	Group() string
+	Methods() string
+	Path() string
+	SetService(string)
+	SetVersion(string)
+	SetMethods(string)
+	SetPath(string)
+	SetProtocol(string)
+	SetGroup(string)
 }
 
 type DefaultServiceConfig struct {
-	Protocol string `required:"true",default:"dubbo"  yaml:"protocol"  json:"protocol,omitempty"`
-	Service  string `required:"true"  yaml:"service"  json:"service,omitempty"`
-	Group    string `yaml:"group" json:"group,omitempty"`
-	Version  string `yaml:"version" json:"version,omitempty"`
+	DProtocol string `required:"true",default:"dubbo"  yaml:"protocol"  json:"protocol,omitempty"`
+	DService  string `required:"true"  yaml:"service"  json:"service,omitempty"`
+	DGroup    string `yaml:"group" json:"group,omitempty"`
+	DVersion  string `yaml:"version" json:"version,omitempty"`
 }
 
-func (c DefaultServiceConfig) Key() string {
-	return fmt.Sprintf("%s@%s", c.Service, c.Protocol)
+func NewDefaultServiceConfig() ServiceConfig {
+	return &DefaultServiceConfig{}
 }
 
-func (c DefaultServiceConfig) String() string {
-	return fmt.Sprintf("%s@%s-%s-%s", c.Service, c.Protocol, c.Group, c.Version)
+func (c *DefaultServiceConfig) Key() string {
+	return fmt.Sprintf("%s@%s", c.DService, c.DProtocol)
 }
 
-func (c DefaultServiceConfig) ServiceEqual(url *ServiceURL) bool {
-	if c.Protocol != url.Protocol {
+func (c *DefaultServiceConfig) String() string {
+	return fmt.Sprintf("%s@%s-%s-%s", c.DService, c.DProtocol, c.DGroup, c.DVersion)
+}
+
+func (c *DefaultServiceConfig) ServiceEqual(url *DefaultServiceURL) bool {
+	if c.DProtocol != url.Protocol {
 		return false
 	}
 
-	if c.Service != url.Query.Get("interface") {
+	if c.DService != url.Query.Get("interface") {
 		return false
 	}
 
-	if c.Group != url.Group {
+	if c.DGroup != url.Group {
 		return false
 	}
 
-	if c.Version != url.Version {
+	if c.DVersion != url.Version {
 		return false
 	}
 
 	return true
 }
 
-type ProviderServiceConfig struct {
-	DefaultServiceConfig
-	Path    string `yaml:"path" json:"path,omitempty"`
-	Methods string `yaml:"methods" json:"methods,omitempty"`
+func (c *DefaultServiceConfig) Service() string {
+	return c.DService
+}
+
+func (c *DefaultServiceConfig) Protocol() string {
+	return c.DProtocol
+}
+
+func (c *DefaultServiceConfig) Version() string {
+	return c.DVersion
+}
+
+func (c *DefaultServiceConfig) Group() string {
+	return c.DGroup
+}
+func (c *DefaultServiceConfig) SetProtocol(s string) {
+	c.DProtocol = s
+}
+
+func (c *DefaultServiceConfig) SetService(s string) {
+	c.DService = s
+}
+
+type DefaultProviderServiceConfig struct {
+	*DefaultServiceConfig
+	DPath    string `yaml:"path" json:"path,omitempty"`
+	DMethods string `yaml:"methods" json:"methods,omitempty"`
+}
+
+func NewDefaultProviderServiceConfig() ProviderServiceConfig {
+	return &DefaultProviderServiceConfig{
+		DefaultServiceConfig: NewDefaultServiceConfig().(*DefaultServiceConfig),
+	}
+}
+
+func (c *DefaultProviderServiceConfig) Methods() string {
+	return c.DMethods
+}
+
+func (c *DefaultProviderServiceConfig) Path() string {
+	return c.DPath
+}
+
+func (c *DefaultProviderServiceConfig) SetVersion(s string) {
+	c.DVersion = s
+}
+
+func (c *DefaultProviderServiceConfig) SetMethods(s string) {
+	c.DMethods = s
+}
+
+func (c *DefaultProviderServiceConfig) SetPath(s string) {
+	c.DPath = s
+}
+
+func (c *DefaultProviderServiceConfig) SetGroup(s string) {
+	c.DGroup = s
 }
 
 //////////////////////////////////////////
 // service url
 //////////////////////////////////////////
 
-type ServiceURL struct {
+type ServiceURL interface {
+	ServiceConfig() ServiceConfig
+	CheckMethod(string) bool
+}
+
+type DefaultServiceURL struct {
 	Protocol     string
 	Location     string // ip+port
 	Path         string // like  /com.ikurento.dubbo.UserProvider3
@@ -82,12 +170,12 @@ type ServiceURL struct {
 	PrimitiveURL string
 }
 
-func NewServiceURL(urlString string) (*ServiceURL, error) {
+func NewDefaultServiceURL(urlString string) (*DefaultServiceURL, error) {
 	var (
 		err          error
 		rawUrlString string
 		serviceUrl   *url.URL
-		s            = &ServiceURL{}
+		s            = &DefaultServiceURL{}
 	)
 
 	rawUrlString, err = url.QueryUnescape(urlString)
@@ -131,25 +219,25 @@ func NewServiceURL(urlString string) (*ServiceURL, error) {
 	return s, nil
 }
 
-func (s ServiceURL) String() string {
+func (s DefaultServiceURL) String() string {
 	return fmt.Sprintf(
-		"ServiceURL{Protocol:%s, Location:%s, Path:%s, Ip:%s, Port:%s, "+
+		"DefaultServiceURL{Protocol:%s, Location:%s, Path:%s, Ip:%s, Port:%s, "+
 			"Timeout:%s, Version:%s, Group:%s, Weight:%d, Query:%+v}",
 		s.Protocol, s.Location, s.Path, s.Ip, s.Port,
 		s.Timeout, s.Version, s.Group, s.Weight, s.Query)
 }
 
-func (s *ServiceURL) ServiceConfig() DefaultServiceConfig {
+func (s *DefaultServiceURL) ServiceConfig() ServiceConfig {
 	interfaceName := s.Query.Get("interface")
-	return DefaultServiceConfig{
-		Protocol: s.Protocol,
-		Service:  interfaceName,
-		Group:    s.Group,
-		Version:  s.Version,
+	return &DefaultServiceConfig{
+		DProtocol: s.Protocol,
+		DService:  interfaceName,
+		DGroup:    s.Group,
+		DVersion:  s.Version,
 	}
 }
 
-func (s *ServiceURL) CheckMethod(method string) bool {
+func (s *DefaultServiceURL) CheckMethod(method string) bool {
 	var (
 		methodArray []string
 	)

--- a/registry/zookeeper/listener.go
+++ b/registry/zookeeper/listener.go
@@ -82,7 +82,7 @@ func (l *zkEventListener) listenServiceNodeEvent(zkPath string) bool {
 	return false
 }
 
-func (l *zkEventListener) handleZkNodeEvent(zkPath string, children []string, conf registry.DefaultServiceConfig) {
+func (l *zkEventListener) handleZkNodeEvent(zkPath string, children []string, conf registry.ServiceConfig) {
 	contains := func(s []string, e string) bool {
 		for _, a := range s {
 			if a == e {
@@ -102,7 +102,7 @@ func (l *zkEventListener) handleZkNodeEvent(zkPath string, children []string, co
 	// a node was added -- listen the new node
 	var (
 		newNode    string
-		serviceURL *registry.ServiceURL
+		serviceURL *registry.DefaultServiceURL
 	)
 	for _, n := range newChildren {
 		if contains(children, n) {
@@ -111,9 +111,9 @@ func (l *zkEventListener) handleZkNodeEvent(zkPath string, children []string, co
 
 		newNode = path.Join(zkPath, n)
 		log.Info("add zkNode{%s}", newNode)
-		serviceURL, err = registry.NewServiceURL(n)
+		serviceURL, err = registry.NewDefaultServiceURL(n)
 		if err != nil {
-			log.Error("NewServiceURL(%s) = error{%v}", n, jerrors.ErrorStack(err))
+			log.Error("NewDefaultServiceURL(%s) = error{%v}", n, jerrors.ErrorStack(err))
 			continue
 		}
 		if !conf.ServiceEqual(serviceURL) {
@@ -123,7 +123,7 @@ func (l *zkEventListener) handleZkNodeEvent(zkPath string, children []string, co
 		log.Info("add serviceURL{%s}", serviceURL)
 		l.events <- zkEvent{&registry.ServiceEvent{Action: registry.ServiceAdd, Service: serviceURL}, nil}
 		// listen l service node
-		go func(node string, serviceURL *registry.ServiceURL) {
+		go func(node string, serviceURL *registry.DefaultServiceURL) {
 			log.Info("delete zkNode{%s}", node)
 			if l.listenServiceNodeEvent(node) {
 				log.Info("delete serviceURL{%s}", serviceURL)
@@ -142,21 +142,21 @@ func (l *zkEventListener) handleZkNodeEvent(zkPath string, children []string, co
 
 		oldNode = path.Join(zkPath, n)
 		log.Warn("delete zkPath{%s}", oldNode)
-		serviceURL, err = registry.NewServiceURL(n)
+		serviceURL, err = registry.NewDefaultServiceURL(n)
 		if !conf.ServiceEqual(serviceURL) {
 			log.Warn("serviceURL{%s} has been deleted is not compatible with ServiceConfig{%#v}", serviceURL, conf)
 			continue
 		}
 		log.Warn("delete serviceURL{%s}", serviceURL)
 		if err != nil {
-			log.Error("NewServiceURL(i{%s}) = error{%v}", n, jerrors.ErrorStack(err))
+			log.Error("NewDefaultServiceURL(i{%s}) = error{%v}", n, jerrors.ErrorStack(err))
 			continue
 		}
 		l.events <- zkEvent{&registry.ServiceEvent{Action: registry.ServiceDel, Service: serviceURL}, nil}
 	}
 }
 
-func (l *zkEventListener) listenDirEvent(zkPath string, conf registry.DefaultServiceConfig) {
+func (l *zkEventListener) listenDirEvent(zkPath string, conf registry.ServiceConfig) {
 	l.wg.Add(1)
 	defer l.wg.Done()
 
@@ -222,16 +222,16 @@ func (l *zkEventListener) listenDirEvent(zkPath string, conf registry.DefaultSer
 // registry.go:Listen -> listenServiceEvent -> listenDirEvent -> listenServiceNodeEvent
 //                            |
 //                            --------> listenServiceNodeEvent
-func (l *zkEventListener) listenServiceEvent(conf registry.DefaultServiceConfig) {
+func (l *zkEventListener) listenServiceEvent(conf registry.ServiceConfig) {
 	var (
 		err        error
 		zkPath     string
 		dubboPath  string
 		children   []string
-		serviceURL *registry.ServiceURL
+		serviceURL *registry.DefaultServiceURL
 	)
 
-	zkPath = fmt.Sprintf("/dubbo/%s/providers", conf.Service)
+	zkPath = fmt.Sprintf("/dubbo/%s/providers", conf.Service())
 
 	l.serviceMapLock.Lock()
 	_, ok := l.serviceMap[zkPath]
@@ -254,9 +254,9 @@ func (l *zkEventListener) listenServiceEvent(conf registry.DefaultServiceConfig)
 
 	for _, c := range children {
 
-		serviceURL, err = registry.NewServiceURL(c)
+		serviceURL, err = registry.NewDefaultServiceURL(c)
 		if err != nil {
-			log.Error("NewServiceURL(r{%s}) = error{%v}", c, err)
+			log.Error("NewDefaultServiceURL(r{%s}) = error{%v}", c, err)
 			continue
 		}
 		if !conf.ServiceEqual(serviceURL) {
@@ -269,7 +269,7 @@ func (l *zkEventListener) listenServiceEvent(conf registry.DefaultServiceConfig)
 		// listen l service node
 		dubboPath = path.Join(zkPath, c)
 		log.Info("listen dubbo service key{%s}", dubboPath)
-		go func(zkPath string, serviceURL *registry.ServiceURL) {
+		go func(zkPath string, serviceURL *registry.DefaultServiceURL) {
 			if l.listenServiceNodeEvent(dubboPath) {
 				log.Debug("delete serviceUrl{%s}", serviceURL)
 				l.events <- zkEvent{&registry.ServiceEvent{Action: registry.ServiceDel, Service: serviceURL}, nil}
@@ -279,7 +279,7 @@ func (l *zkEventListener) listenServiceEvent(conf registry.DefaultServiceConfig)
 	}
 
 	log.Info("listen dubbo path{%s}", zkPath)
-	go func(zkPath string, conf registry.DefaultServiceConfig) {
+	go func(zkPath string, conf registry.ServiceConfig) {
 		l.listenDirEvent(zkPath, conf)
 		log.Warn("listenDirEvent(zkPath{%s}) goroutine exit now", zkPath)
 	}(zkPath, conf)

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -2,6 +2,7 @@ package zookeeper
 
 import (
 	"fmt"
+	"github.com/dubbo/dubbo-go/plugins"
 	"net/url"
 	"os"
 	"strconv"
@@ -35,6 +36,7 @@ var (
 func init() {
 	processID = fmt.Sprintf("%d", os.Getpid())
 	localIP, _ = gxnet.GetLocalIP()
+	plugins.PluggableRegistries["zookeeper"] = NewZkRegistry
 }
 
 type ZkRegistryConfig struct {

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -338,7 +338,9 @@ func (r *ZkRegistry) register(c registry.ServiceConfig) error {
 	}
 	params.Add("revision", revision) // revision是pox.xml中application的version属性的值
 
-	if r.DubboType == registry.PROVIDER {
+	switch r.DubboType {
+
+	case registry.PROVIDER:
 		if conf, ok = c.(registry.ProviderServiceConfig); !ok {
 			return jerrors.Errorf("conf is not ProviderServiceConfig")
 		}
@@ -392,7 +394,7 @@ func (r *ZkRegistry) register(c registry.ServiceConfig) error {
 		dubboPath = fmt.Sprintf("/dubbo/%s/%s", conf.Service(), (registry.DubboType(registry.PROVIDER)).String())
 		log.Debug("provider path:%s, url:%s", dubboPath, rawURL)
 
-	} else if r.DubboType == registry.CONSUMER {
+	case registry.CONSUMER:
 		dubboPath = fmt.Sprintf("/dubbo/%s/%s", c.Service(), registry.DubboNodes[registry.CONSUMER])
 		r.cltLock.Lock()
 		err = r.client.Create(dubboPath)
@@ -431,7 +433,7 @@ func (r *ZkRegistry) register(c registry.ServiceConfig) error {
 
 		dubboPath = fmt.Sprintf("/dubbo/%s/%s", c.Service(), (registry.DubboType(registry.CONSUMER)).String())
 		log.Debug("consumer path:%s, url:%s", dubboPath, rawURL)
-	} else {
+	default:
 		return jerrors.Errorf("@c{%v} type is not DefaultServiceConfig or DefaultProviderServiceConfig", c)
 	}
 

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -159,6 +159,7 @@ func (r *ZkRegistry) validateZookeeperClient() error {
 		if err != nil {
 			log.Warn("newZookeeperClient(name{%s}, zk addresss{%v}, timeout{%d}) = error{%v}",
 				RegistryZkClient, r.Address, r.Timeout.String(), err)
+			return jerrors.Annotatef(err, "newZookeeperClient(address:%+v)", r.Address)
 		}
 	}
 	if r.client.conn == nil {
@@ -239,8 +240,7 @@ LOOP:
 	}
 }
 
-
-func (r *ZkRegistry) Register(regConf registry.ServiceConfig) error {
+func (r *ZkRegistry) Register(conf registry.ServiceConfig) error {
 	var (
 		ok       bool
 		err      error
@@ -248,18 +248,12 @@ func (r *ZkRegistry) Register(regConf registry.ServiceConfig) error {
 	)
 	switch r.DubboType {
 	case registry.CONSUMER:
-
-		var conf registry.DefaultServiceConfig
-		if conf, ok = regConf.(registry.DefaultServiceConfig); !ok {
-			return jerrors.Errorf("the type of @regConf %T is not registry.ServiceConfig", regConf)
-		}
-
 		ok = false
 		r.cltLock.Lock()
 		_, ok = r.services[conf.Key()]
 		r.cltLock.Unlock()
 		if ok {
-			return jerrors.Errorf("Service{%s} has been registered", conf.Service)
+			return jerrors.Errorf("Service{%s} has been registered", conf.Service())
 		}
 
 		err = r.register(conf)
@@ -279,10 +273,6 @@ func (r *ZkRegistry) Register(regConf registry.ServiceConfig) error {
 			go listener.listenServiceEvent(conf)
 		}
 	case registry.PROVIDER:
-		var conf registry.ProviderServiceConfig
-		if conf, ok = regConf.(registry.ProviderServiceConfig); !ok {
-			return jerrors.Errorf("the tyep of @regConf{%v} is not ProviderServiceConfig", regConf)
-		}
 
 		// 检验服务是否已经注册过
 		ok = false
@@ -307,8 +297,6 @@ func (r *ZkRegistry) Register(regConf registry.ServiceConfig) error {
 		log.Debug("(ZkProviderRegistry)Register(conf{%#v})", conf)
 	}
 
-
-
 	return nil
 }
 
@@ -321,6 +309,8 @@ func (r *ZkRegistry) register(c registry.ServiceConfig) error {
 		rawURL     string
 		encodedURL string
 		dubboPath  string
+		conf       registry.ProviderServiceConfig
+		ok         bool
 	)
 
 	err = r.validateZookeeperClient()
@@ -347,16 +337,14 @@ func (r *ZkRegistry) register(c registry.ServiceConfig) error {
 	params.Add("revision", revision) // revision是pox.xml中application的version属性的值
 
 	if r.DubboType == registry.PROVIDER {
-		conf, ok := c.(registry.ProviderServiceConfig)
-		if !ok {
-			return fmt.Errorf("the type of @c:%+v is not registry.ProviderServiceConfig", c)
+		if conf, ok = c.(registry.ProviderServiceConfig); !ok {
+			return jerrors.Errorf("conf is not ProviderServiceConfig")
 		}
-
-		if conf.Service == "" || conf.Methods == "" {
-			return jerrors.Errorf("conf{Service:%s, Methods:%s}", conf.Service, conf.Methods)
+		if conf.Service() == "" || conf.Methods() == "" {
+			return jerrors.Errorf("conf{Service:%s, Methods:%s}", conf.Service(), conf.Methods())
 		}
 		// 先创建服务下面的provider node
-		dubboPath = fmt.Sprintf("/dubbo/%s/%s", conf.Service, registry.DubboNodes[registry.PROVIDER])
+		dubboPath = fmt.Sprintf("/dubbo/%s/%s", conf.Service(), registry.DubboNodes[registry.PROVIDER])
 		r.cltLock.Lock()
 		err = r.client.Create(dubboPath)
 		r.cltLock.Unlock()
@@ -365,10 +353,10 @@ func (r *ZkRegistry) register(c registry.ServiceConfig) error {
 			return jerrors.Annotatef(err, "zkclient.Create(path:%s)", dubboPath)
 		}
 		params.Add("anyhost", "true")
-		params.Add("interface", conf.DefaultServiceConfig.Service)
+		params.Add("interface", conf.Service())
 
-		if conf.DefaultServiceConfig.Group != "" {
-			params.Add("group", conf.DefaultServiceConfig.Group)
+		if conf.Group() != "" {
+			params.Add("group", conf.Group())
 		}
 		// dubbo java consumer来启动找provider url时，因为category不匹配，会找不到provider，导致consumer启动不了,所以使用consumers&providers
 		// DubboRole               = [...]string{"consumer", "", "", "provider"}
@@ -378,36 +366,32 @@ func (r *ZkRegistry) register(c registry.ServiceConfig) error {
 
 		params.Add("side", (registry.DubboType(registry.PROVIDER)).Role())
 
-		if conf.DefaultServiceConfig.Version != "" {
-			params.Add("version", conf.DefaultServiceConfig.Version)
+		if conf.Version() != "" {
+			params.Add("version", conf.Version())
 		}
-		if conf.Methods != "" {
-			params.Add("methods", conf.Methods)
+		if conf.Methods() != "" {
+			params.Add("methods", conf.Methods())
 		}
 		log.Debug("provider zk url params:%#v", params)
-		if conf.Path == "" {
-			conf.Path = localIP
+		var path = conf.Path()
+		if path == "" {
+			path = localIP
 		}
 
-		urlPath = conf.Service
+		urlPath = conf.Service()
 		if r.zkPath[urlPath] != 0 {
 			urlPath += strconv.Itoa(r.zkPath[urlPath])
 		}
 		r.zkPath[urlPath]++
-		rawURL = fmt.Sprintf("%s://%s/%s?%s", conf.Protocol, conf.Path, urlPath, params.Encode())
+		rawURL = fmt.Sprintf("%s://%s/%s?%s", conf.Protocol(), path, urlPath, params.Encode())
 		encodedURL = url.QueryEscape(rawURL)
 
 		// 把自己注册service providers
-		dubboPath = fmt.Sprintf("/dubbo/%s/%s", conf.Service, (registry.DubboType(registry.PROVIDER)).String())
+		dubboPath = fmt.Sprintf("/dubbo/%s/%s", conf.Service(), (registry.DubboType(registry.PROVIDER)).String())
 		log.Debug("provider path:%s, url:%s", dubboPath, rawURL)
 
 	} else if r.DubboType == registry.CONSUMER {
-		conf, ok := c.(registry.DefaultServiceConfig)
-		if !ok {
-			return fmt.Errorf("the type of @c:%+v is not registry.ServiceConfig", c)
-		}
-
-		dubboPath = fmt.Sprintf("/dubbo/%s/%s", conf.Service, registry.DubboNodes[registry.CONSUMER])
+		dubboPath = fmt.Sprintf("/dubbo/%s/%s", c.Service(), registry.DubboNodes[registry.CONSUMER])
 		r.cltLock.Lock()
 		err = r.client.Create(dubboPath)
 		r.cltLock.Unlock()
@@ -415,7 +399,7 @@ func (r *ZkRegistry) register(c registry.ServiceConfig) error {
 			log.Error("zkClient.create(path{%s}) = error{%v}", dubboPath, jerrors.ErrorStack(err))
 			return jerrors.Trace(err)
 		}
-		dubboPath = fmt.Sprintf("/dubbo/%s/%s", conf.Service, registry.DubboNodes[registry.PROVIDER])
+		dubboPath = fmt.Sprintf("/dubbo/%s/%s", c.Service(), registry.DubboNodes[registry.PROVIDER])
 		r.cltLock.Lock()
 		err = r.client.Create(dubboPath)
 		r.cltLock.Unlock()
@@ -424,29 +408,29 @@ func (r *ZkRegistry) register(c registry.ServiceConfig) error {
 			return jerrors.Trace(err)
 		}
 
-		params.Add("protocol", conf.Protocol)
-		params.Add("interface", conf.Service)
+		params.Add("protocol", c.Protocol())
+		params.Add("interface", c.Service())
 		revision = r.ApplicationConfig.Version
 		if revision == "" {
 			revision = "0.1.0"
 		}
 		params.Add("revision", revision)
-		if conf.Group != "" {
-			params.Add("group", conf.Group)
+		if c.Group() != "" {
+			params.Add("group", c.Group())
 		}
 		params.Add("category", (registry.DubboType(registry.CONSUMER)).String())
 		params.Add("dubbo", "dubbogo-consumer-"+version.Version)
 
-		if conf.Version != "" {
-			params.Add("version", conf.Version)
+		if c.Version() != "" {
+			params.Add("version", c.Version())
 		}
-		rawURL = fmt.Sprintf("consumer://%s/%s?%s", localIP, conf.Service+conf.Version, params.Encode())
+		rawURL = fmt.Sprintf("consumer://%s/%s?%s", localIP, c.Service()+c.Version(), params.Encode())
 		encodedURL = url.QueryEscape(rawURL)
 
-		dubboPath = fmt.Sprintf("/dubbo/%s/%s", conf.Service, (registry.DubboType(registry.CONSUMER)).String())
+		dubboPath = fmt.Sprintf("/dubbo/%s/%s", c.Service(), (registry.DubboType(registry.CONSUMER)).String())
 		log.Debug("consumer path:%s, url:%s", dubboPath, rawURL)
 	} else {
-		return jerrors.Errorf("@c{%v} type is not DefaultServiceConfig or ProviderServiceConfig", c)
+		return jerrors.Errorf("@c{%v} type is not DefaultServiceConfig or DefaultProviderServiceConfig", c)
 	}
 
 	err = r.registerTempZookeeperNode(dubboPath, encodedURL)


### PR DESCRIPTION
We no longer pass the DefaultServiceConfig object in methods calling, but should pass the ServiceConfig interface  in methods calling.
And ServiceConfig can be pluginization by user who use dubbo-go now. 
You can implement the ServiceConfig interface for your own personalized needs about service configuration !

